### PR TITLE
Simpler and faster garbage collector

### DIFF
--- a/src/core/lambda.c
+++ b/src/core/lambda.c
@@ -51,7 +51,7 @@ MinimObject *eval_lambda(MinimLambda* lam, MinimEnv *env, size_t argc, MinimObje
     MinimEnv *env2;
     jmp_buf *pjmp_buf;
 
-    pjmp_buf = GC_alloc(sizeof(jmp_buf));
+    pjmp_buf = GC_alloc_atomic(sizeof(jmp_buf));
     jmp = minim_jmp(pjmp_buf, NULL);
     if (setjmp(*pjmp_buf) != 0)      // if jumped back
     {

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -10,7 +10,13 @@ MinimObject *minim_input_port = NULL;
 
 // Destructors
 
-static void GC_minim_port_dtor(void *ptr)
+static void GC_file_port_mrk(void (*mrk)(void*, void*), void *gc, void *ptr) {
+    MinimObject *o = (MinimObject *) ptr;
+    mrk(gc, MINIM_PORT_FILE(o));
+    mrk(gc, MINIM_PORT_NAME(o));
+}
+
+static void GC_file_port_dtor(void *ptr)
 {
     MinimObject *obj;
     
@@ -36,7 +42,7 @@ MinimObject *minim_exactnum(void *num)
 
 MinimObject *minim_inexactnum(double num)
 {
-    MinimObject *o = GC_alloc(minim_inexactnum_size);
+    MinimObject *o = GC_alloc_atomic(minim_inexactnum_size);
     o->type = MINIM_OBJ_INEXACT;
     MINIM_INEXACTNUM(o) = num;
     log_obj_created();
@@ -188,7 +194,7 @@ MinimObject *minim_err(void *err)
 
 MinimObject *minim_char(unsigned int ch)
 {
-    MinimObject *o = GC_alloc(minim_char_size);
+    MinimObject *o = GC_alloc_atomic(minim_char_size);
     o->type = MINIM_OBJ_CHAR;
     MINIM_CHAR(o) = ch;
     log_obj_created();
@@ -207,7 +213,7 @@ MinimObject *minim_jmp(void *ptr, void *val)
 
 MinimObject *minim_file_port(FILE *f, uint8_t mode)
 {
-    MinimObject *o = GC_alloc_opt(minim_port_size, GC_minim_port_dtor, NULL);
+    MinimObject *o = GC_alloc_opt(minim_port_size, GC_file_port_dtor, GC_file_port_mrk);
     o->type = MINIM_OBJ_PORT;
     MINIM_PORT_TYPE(o) = MINIM_PORT_TYPE_FILE;
     MINIM_PORT_MODE(o) = mode;

--- a/src/gc/README.md
+++ b/src/gc/README.md
@@ -1,6 +1,6 @@
 # Minim-GC
 Garbage collector developed for the [Minim](https://github.com/bksaiki/Minim) project.
-The Minim-GC is a conservative, generational, thread-local, Mark&Sweep garbage collector.
+The Minim-GC is a conservative, thread-local, Mark&Sweep garbage collector.
 It only works for 64-bit programs and is less efficient since it calls the underlying `malloc`.
 Much of this work is based on the [Tiny Garbage Collector](https://github.com/orangeduck/tgc) which
   in turn, borrows from the garbage collector from [Cello](https://github.com/orangeduck/Cello).
@@ -37,9 +37,9 @@ Allocates at least `size` bytes of memory that will be collected when
 ```c
 void *GC_calloc(size_t nmem, size_t size);
 ```
-Allocates an array of `nmem` elements, each of which is `size` bytes.
-Initializes all bits to 0.
-Like `GC_malloc(size)`, this memory will be garbage collected.
+Allocates an array of `nmem` elements, each of which is `size` bytes,
+  that will be collected when no pointer references it.
+Sets all bits to 0.
   
 ```c
 void *GC_realloc(void *ptr, size_t size);
@@ -75,9 +75,8 @@ Manually frees the memory block at `ptr`. Runs the destructor by the memory bloc
 
 ```c
 void GC_collect();
-void GC_collect_minor();
 ```
-Manually runs a full and minor cycle of garbage collection.
+Manually runs a cycle of garbage collection.
 
 ### Destructors and Markers
 ```c

--- a/src/gc/gc-impl.c
+++ b/src/gc/gc-impl.c
@@ -8,880 +8,441 @@
 
 #include "gc-impl.h"
 
-#define NUM_PRIME_SIZES     23
 #define POINTER_SIZE        sizeof(void*)
 
-static size_t PRIME_SIZES[NUM_PRIME_SIZES] = {
-                        53,       97,        193,
-    389,      769,      1543,     3079,      6151, 
-    12289,    24593,    49157,    98137,     196613,
-    393241,   786433,   1572869,  3145739,   6291469,
-    12582917, 25165843, 50331653, 100663319, 201326611
+// GC record table 
+static size_t bucket_sizes[] = {
+    4099,
+    8209,
+    16411,
+    32771,
+    65537,
+    131101,
+    262147,
+    524309,
+    1048583,
+    2097169,
+    4194319,
+    8388617,
+    16777259,
+    33554467,
+    67108879,
+    134217757,
+    268435459,
+    536870923,
+    1073741827,
+    2147483659,
+    4294967311,
+    8589934609,
+    17179869209,
+    34359738421,
+    68719476767,
+    137438953481,
+    274877906951,
+    549755813911,
+    1099511627791,
+    2199023255579,
+    4398046511119,
+    8796093022237,
+    17592186044423,
+    35184372088891,
+    70368744177679,
+    140737488355333,
+    281474976710677,
+    562949953421381,
+    1125899906842679,
+    2251799813685269,
+    4503599627370517,
+    9007199254740997,
+    18014398509482143,
+    36028797018963971,
+    72057594037928017,
+    144115188075855881,
+    288230376151711813,
+    576460752303423619,
+    1152921504606847009,
+    2305843009213693967,
+    4611686018427388039,
+    0
 };
 
 void GC_atomic_mrk(void (*)(void*, void*), void*, void*);
 
 /*************** Helper functions *****************/
 
+#define gc_load(gc)     (gc_load2((gc)->size, (gc)->alloc))
+#define gc_load2(s, a)  (((double) (s)) / ((double) (a)))
 #define gc_hash(ptr)    (((size_t) ptr) >> 3)
 
-static size_t gc_probe(size_t i, size_t h, size_t c) {
-    long n = i - (h - 1);
-    return (n < 0) ? c + n : n;
-}
+#define ptr_arr_ref(arr, n)     (((void**) (arr))[n])
+#define ptr_ref(p)              (*((void**) (p)))
 
-static void gc_add_young_pool(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk, int update, int root) {
-    size_t h, i, j, p;
-    gc_block_t item, t;
-
-    i = gc_hash(ptr) % gc->youngc;
-    j = 0;
-
-    item.ptr = ptr;
-    item.dtor = dtor;
-    item.mrk = mrk;
-    item.size = size;
-    item.hash = i + 1;
-    item.flags = (root ? GC_BLOCK_ROOT : 0);
+// Inserts an existing bucket into the record table updating `b->next`.
+static gc_record_t *
+insert_record(gc_t *gc,
+              gc_bucket_t *b) {
+    size_t i;
     
-    while (1) {
-        h = gc->young[i].hash;
-        if (!h) {
-            gc->young[i] = item;
-            if (update) {
-                gc->allocs += size;
-                gc->dirty += size;
-                ++gc->nyoung;
+    // compute index and insert
+    i = b->record.hash % gc->alloc;
+    b->next = gc->buckets[i];
+    gc->buckets[i] = b;
+    return &b->record;
+}
+
+// Creates a new record, adds it to the table and returns
+// a pointer to it. Does not update any gc stats.
+static gc_record_t *
+add_record(gc_t *gc,
+           void *ptr,
+           size_t size,
+           gc_dtor_t dtor,
+           gc_mark_t mrk,
+           int root) {
+    gc_bucket_t *nb;
+
+    // create record
+    nb = (gc_bucket_t *) malloc(sizeof(gc_bucket_t));
+    nb->record.ptr = ptr;
+    nb->record.dtor = dtor;
+    nb->record.mrk = mrk;
+    nb->record.size = size;
+    nb->record.hash = gc_hash(ptr);
+    nb->record.flags = (root ? GC_BLOCK_ROOT : 0x0);
+
+    // insert and return record
+    return insert_record(gc, nb);
+}
+
+static void
+remove_record(gc_t *gc,
+              size_t i,
+              gc_bucket_t *pb,
+              gc_bucket_t *b,
+              gc_bucket_t *nb) {
+    gc_record_t *r = &b->record;
+
+    // call dtor if needed and free record and bucket entry
+    if (r->dtor)    r->dtor(r->ptr);
+    free(r->ptr);
+    free(b);
+
+    // repair bucket entries as needed
+    if (pb)     pb->next = nb;
+    else        gc->buckets[i] = nb;
+}
+
+static void
+gc_resize_if_needed(gc_t *gc) {
+    if (gc_load(gc) > GC_TABLE_LOAD_FACTOR) {      // needs larger size
+        gc_bucket_t **old_buckets = gc->buckets;
+        size_t old_alloc = gc->alloc;
+
+        // update size and create new buckets
+        ++gc->alloc_ptr;
+        gc->alloc = *gc->alloc_ptr;
+        gc->buckets = (gc_bucket_t **) calloc(gc->alloc, sizeof(gc_bucket_t*));
+
+        // rehash
+        for (size_t i = 0; i < old_alloc; ++i) {
+            gc_bucket_t *b = old_buckets[i];
+            while (b) {
+                gc_bucket_t *nb = b->next;
+                insert_record(gc, b);
+                b = nb;
             }
-            return;
         }
 
-        if (gc->young[i].ptr == item.ptr)
-            return;
-
-        p = gc_probe(i, h, gc->youngc);
-        if (j >= p) {           // shift blocks (LIFO, locality)
-            t = gc->young[i];
-            gc->young[i] = item;
-            item = t;
-            j = p;
-        }
-
-        i = (i + 1) % gc->youngc;
-        ++j;
+        free(old_buckets);
     }
 }
 
-static void gc_add_old_pool(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk, int update, int root) {
-    size_t h, i, j, p;
-    gc_block_t item, t;
+static void
+gc_mark_ptr(gc_t *gc,
+            void *ptr) {
+    size_t i;
 
-    i = gc_hash(ptr) % gc->oldc;
-    j = 0;
+// #if GC_HEAP_HEURISTIC
+//     // decent heuristic for possible "heap" location
+//     if (ptr < (void*) gc_mark_ptr_young || ptr > gc->stack_bottom)
+//         return;
+// #endif
 
-    item.ptr = ptr;
-    item.dtor = dtor;
-    item.mrk = mrk;
-    item.size = size;
-    item.hash = i + 1;
-    item.flags = (root ? GC_BLOCK_ROOT : 0);
-    
-    while (1) {
-        h = gc->old[i].hash;
-        if (!h) {
-            gc->old[i] = item;
-            if (update) ++gc->nold;
-            return;
-        }
-
-        if (gc->old[i].ptr == item.ptr)
-            return;
-
-        p = gc_probe(i, h, gc->oldc);
-        if (j >= p) {
-            t = gc->old[i];
-            gc->old[i] = item;
-            item = t;
-            j = p;
-        }
-
-        i = (i + 1) % gc->oldc;
-        ++j;
-    }
-}
-
-static void gc_resize_if_needed(gc_t *gc) {
-    gc_block_t *old;
-    double load;
-    size_t s;
-
-    load = (double) gc->nyoung / (double) gc->youngc;
-    if (load > GC_TABLE_LOAD_FACTOR) {
-        for (s = 0; s < NUM_PRIME_SIZES; ++s) {
-            if (gc->youngc == PRIME_SIZES[s])
-                break;
-        }
-
-        old = gc->young;
-        gc->young = calloc(PRIME_SIZES[s + 1], sizeof(gc_block_t));
-        gc->youngc = PRIME_SIZES[s + 1];
-        for (size_t i = 0; i < PRIME_SIZES[s]; ++i) {
-            if (old[i].hash)
-                gc_add_young_pool(gc, old[i].ptr, old[i].size, old[i].dtor, old[i].mrk,
-                                  0, (old[i].flags & GC_BLOCK_ROOT));
-        }
-
-        free(old);
-    } else if (gc->youngc > PRIME_SIZES[0] && (load < GC_TABLE_LOAD_FACTOR / 4.0)) {
-        size_t n;
-
-        for (s = 0; s < NUM_PRIME_SIZES; ++s) {
-            if (gc->youngc == PRIME_SIZES[s])
-                break;
-        }
-
-        for (n = s - 1; n > 0; --n) {
-            if (PRIME_SIZES[n] < 4 * gc->nyoung)
-                break;
-        }
-
-        old = gc->young;
-        gc->young = calloc(PRIME_SIZES[n], sizeof(gc_block_t));
-        gc->youngc = PRIME_SIZES[n];
-        for (size_t i = 0; i < PRIME_SIZES[s]; ++i) {
-            if (old[i].hash)
-                gc_add_young_pool(gc, old[i].ptr, old[i].size, old[i].dtor, old[i].mrk,
-                                  0, (old[i].flags & GC_BLOCK_ROOT));
-        }
-
-        free(old);
-    }
-}
-
-static void gc_increase_old_pool(gc_t *gc, size_t incr) {
-    gc_block_t *old;
-    double load;
-    size_t s, n;
-
-    load = (double) (gc->nold + incr) / (double) gc->oldc;
-    if (load > GC_TABLE_LOAD_FACTOR) {
-        old = gc->old;
-        n = gc->oldc;
-
-        for (s = 0; PRIME_SIZES[s] < 2 * (gc->nold + incr); ++s);
-        gc->old = calloc(PRIME_SIZES[s], sizeof(gc_block_t));
-        gc->oldc = PRIME_SIZES[s];
-
-        for (size_t i = 0; i < n; ++i) {
-            if (old[i].hash)
-                gc_add_old_pool(gc, old[i].ptr, old[i].size, old[i].dtor, old[i].mrk,
-                                0, (old[i].flags & GC_BLOCK_ROOT));
-        }
-
-        free(old);
-    }
-}
-
-static void gc_shrink_old_pool(gc_t *gc) {
-    gc_block_t *old;
-    double load;
-    size_t s, n;
-
-    load = (double) gc->nold / (double) gc->oldc;
-    if (gc->oldc > PRIME_SIZES[0] && (load < GC_TABLE_LOAD_FACTOR / 4.0)) {
-        for (s = 0; s < NUM_PRIME_SIZES; ++s) {
-            if (gc->oldc == PRIME_SIZES[s])
-                break;
-        }
-
-        for (n = s - 1; n > 0; --n) {
-            if (PRIME_SIZES[n] < 4 * gc->nold)
-                break;
-        }
-
-        old = gc->old;
-        gc->old = calloc(PRIME_SIZES[n], sizeof(gc_block_t));
-        gc->oldc = PRIME_SIZES[n];
-        for (size_t i = 0; i < PRIME_SIZES[s]; ++i) {
-            if (old[i].hash)
-                gc_add_old_pool(gc, old[i].ptr, old[i].size, old[i].dtor, old[i].mrk,
-                                0, (old[i].flags & GC_BLOCK_ROOT));
-        }
-
-        free(old);
-    }
-}
-
-static void gc_mark_ptr_young(gc_t *gc, void *ptr) {
-    size_t h, i, j;
-
-#if GC_HEAP_HEURISTIC
-    // decent heuristic for possible "heap" location
-    if (ptr < (void*) gc_mark_ptr_young || ptr > gc->stack_bottom)
+    // early exit: above stack start
+    if (ptr > gc->stack_bottom)
         return;
-#endif
 
-    i = gc_hash(ptr) % gc->youngc;
-    j = 0;
-    while (1) {
-        h = gc->young[i].hash;
-        if (!h || j > gc_probe(i, h, gc->youngc))
-            return;
-
-        if (ptr == gc->young[i].ptr) {
-            if (gc->young[i].flags & GC_BLOCK_MARK ||
-                gc->young[i].flags & GC_BLOCK_ROOT)
+    i = gc_hash(ptr) % gc->alloc;
+    for (gc_bucket_t *b = gc->buckets[i]; b; b = b->next) {
+        gc_record_t *r = &b->record;
+        if (ptr == r->ptr) {    // found correct record
+            if (r->flags & GC_BLOCK_MARK ||     // early exit if root or already marked
+                r->flags & GC_BLOCK_ROOT)
                 return;
-                
-            gc->young[i].flags |= GC_BLOCK_MARK;
-#if GC_USE_CUSTOM_MARKERS == 2
-            if (!gc->young[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_young(gc, ((void**) gc->young[i].ptr)[k]);
-            } else if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->young[i].mrk(gc_mark_ptr_young, gc, gc->young[i].ptr);
-            }
-#elif GC_USE_CUSTOM_MARKERS == 1
-            if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk)              // default (conservative)
-            {
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_young(gc, ((void**) gc->young[i].ptr)[k]);
-            }
-#else
-            for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_young(gc, ((void**) gc->young[i].ptr)[k]);
-#endif
 
-            return;
-        }
+            // set mark flag
+            r->flags |= GC_BLOCK_MARK;
 
-        i = (i + 1) % gc->youngc;
-        ++j;
-    }
-}
-
-static void gc_mark_ptr_all(gc_t *gc, void *ptr) {
-    size_t h, i, j;
-
-#if GC_HEAP_HEURISTIC
-    // decent heuristic for possible "heap" location
-    if (ptr < (void*) gc_mark_ptr_all || ptr > gc->stack_bottom)
-        return;
-#endif
-
-    // try younger generation first
-    i = gc_hash(ptr) % gc->youngc;
-    j = 0;
-    while (1) {
-        h = gc->young[i].hash;
-        if (!h || j > gc_probe(i, h, gc->youngc))
-            break;
-
-        if (ptr == gc->young[i].ptr) {
-            if (gc->young[i].flags & GC_BLOCK_MARK ||
-                gc->young[i].flags & GC_BLOCK_ROOT)
-                return;
-                
-            gc->young[i].flags |= GC_BLOCK_MARK;
-#if GC_USE_CUSTOM_MARKERS == 2
-            if (!gc->young[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->young[i].ptr)[k]);
-            } else if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->young[i].mrk(gc_mark_ptr_all, gc, gc->young[i].ptr);
-            }
-#elif GC_USE_CUSTOM_MARKERS == 1
-            if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk)              // default (conservative)
-            {
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->young[i].ptr)[k]);
-            }
-#else // GC_USE_CUSTOM_MARKERS == 0
-            for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->young[i].ptr)[k]);
-#endif
-
-            return;
-        }
-
-        i = (i + 1) % gc->youngc;
-        ++j;
-    }
-
-    // try older generation
-    i = gc_hash(ptr) % gc->oldc;
-    j = 0;
-    while (1) {
-        h = gc->old[i].hash;
-        if (!h || j > gc_probe(i, h, gc->oldc))
-            return;
-
-        if (ptr == gc->old[i].ptr) {
-            if (gc->old[i].flags & GC_BLOCK_MARK ||
-                gc->old[i].flags & GC_BLOCK_ROOT)
-                return;
-                
-            gc->old[i].flags |= GC_BLOCK_MARK;
-            if (!gc->old[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->old[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->old[i].ptr)[k]);
-            } else if (gc->old[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->old[i].mrk(gc_mark_ptr_all, gc, gc->old[i].ptr);
+            // recurse into pointer block
+            if (!r->mrk) {                                      // default (conservative)
+                for (size_t k = 0; k < r->size / POINTER_SIZE; ++k)
+                    gc_mark_ptr(gc, ptr_arr_ref(r->ptr, k));
+            } else if (r->mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
+                r->mrk(gc_mark_ptr, gc, r->ptr);
             }
 
             return;
         }
-
-        i = (i + 1) % gc->oldc;
-        ++j;
     }
 }
 
 __attribute__((no_sanitize("address")))
-static void gc_mark_stack_young(gc_t *gc) {
+static void
+gc_mark_stack(gc_t *gc) {
     void *b, *t;
 
-    b = gc->stack_bottom; t = &b;
-    for (void *i = t; i <= b; i += POINTER_SIZE)
-        gc_mark_ptr_young(gc, *((void**) i));
+    b = gc->stack_bottom;
+    t = &b;
+    for (void *p = t; p <= b; p += POINTER_SIZE)
+        gc_mark_ptr(gc, ptr_ref(p));
 }
 
-__attribute__((no_sanitize("address")))
-static void gc_mark_stack_all(gc_t *gc) {
-    void *b, *t;
-
-    b = gc->stack_bottom; t = &b;
-    for (void *i = t; i <= b; i += POINTER_SIZE)
-        gc_mark_ptr_all(gc, *((void**) i));
-}
-
-static void gc_mark_young(gc_t *gc) {
+static void
+gc_mark(gc_t *gc) {
     jmp_buf env;
-    void (*volatile mark_stack)(gc_t*) = gc_mark_stack_young;
+    void (*volatile mark_stack)(gc_t*) = gc_mark_stack;
 
     // exit if nothing allocated
-    if (gc->nyoung == 0)
+    if (gc->size == 0)
         return;
 
-    // mark young roots
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash && gc->young[i].flags & GC_BLOCK_ROOT) {
-            gc->young[i].flags |= GC_BLOCK_MARK;
-            if (!gc->young[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_young(gc, ((void**) gc->young[i].ptr)[k]);
-            } else if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->young[i].mrk(gc_mark_ptr_young, gc, gc->young[i].ptr);
+    // mark roots
+    for (size_t i = 0; i < gc->alloc; ++i) {
+        for (gc_bucket_t *b = gc->buckets[i]; b; b = b->next) {
+            gc_record_t *r = &b->record;
+            if (r->flags & GC_BLOCK_ROOT) {
+                if (!r->mrk) {                                      // default (conservative)
+                    for (size_t k = 0; k < r->size / POINTER_SIZE; ++k)
+                        gc_mark_ptr(gc, ptr_arr_ref(r->ptr, k));
+                } else if (r->mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
+                    r->mrk(gc_mark_ptr, gc, r->ptr);
+                }
             }
         }
     }
 
-    // mark all old blocks, descent will stop if we mark old block
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash && !(gc->old[i].flags & GC_BLOCK_MARK)) {
-            gc->old[i].flags |= GC_BLOCK_MARK;
-            if (!gc->old[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->old[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_young(gc, ((void**) gc->old[i].ptr)[k]);
-            } else if (gc->old[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->old[i].mrk(gc_mark_ptr_young, gc, gc->old[i].ptr);
-            }
-        }
-    }
-
+    // push registers and mark stack
     memset(&env, 0, sizeof(jmp_buf));
     setjmp(env);
     mark_stack(gc);
 }
 
-static void gc_mark_all(gc_t *gc) {
-    jmp_buf env;
-    void (*volatile mark_stack)(gc_t*) = gc_mark_stack_all;
-
-    // exit if nothing allocated
-    if (gc->nyoung == 0 && gc->nold == 0)
-        return;
-
-    // mark young roots
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash && gc->young[i].flags & GC_BLOCK_ROOT) {
-            gc->young[i].flags |= GC_BLOCK_MARK;
-            if (!gc->young[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->young[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->young[i].ptr)[k]);
-            } else if (gc->young[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->young[i].mrk(gc_mark_ptr_all, gc, gc->young[i].ptr);
-            }
-        }
-    }
-
-    // mark old roots
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash && gc->old[i].flags & GC_BLOCK_ROOT) {
-            gc->old[i].flags |= GC_BLOCK_MARK;
-            if (!gc->old[i].mrk) {                                        // default (conservative)
-                for (size_t k = 0; k < gc->old[i].size / POINTER_SIZE; ++k)
-                    gc_mark_ptr_all(gc, ((void**) gc->old[i].ptr)[k]);
-            } else if (gc->old[i].mrk != (gc_mark_t) GC_atomic_mrk) {    // custom marker
-                gc->old[i].mrk(gc_mark_ptr_all, gc, gc->old[i].ptr);
-            }
-        }
-    }
-
-    memset(&env, 0, sizeof(jmp_buf));
-    setjmp(env);
-    mark_stack(gc);
-}
-
-static void gc_unmark(gc_t *gc) {
-    // clear young generation
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash)
-            gc->young[i].flags &= ~GC_BLOCK_MARK;
-    }
-    // clear old generation
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash)
-            gc->old[i].flags &= ~GC_BLOCK_MARK;
+static void
+gc_unmark(gc_t *gc) {
+    for (size_t i = 0; i < gc->alloc; ++i) {
+        for (gc_bucket_t *b = gc->buckets[i]; b; b = b->next)
+            b->record.flags &= ~GC_BLOCK_MARK;
     }
 }
 
-static void gc_move_to_old(gc_t *gc) {
-    gc_increase_old_pool(gc, gc->nyoung);
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash)
-            gc_add_old_pool(gc, gc->young[i].ptr, gc->young[i].size,
-                            gc->young[i].dtor, gc->young[i].mrk, 1,
-                            (gc->young[i].flags & GC_BLOCK_ROOT));
-    }
+static void
+gc_sweep(gc_t *gc) {
+    for (size_t i = 0; i < gc->alloc; ++i) {
+        gc_bucket_t *b = gc->buckets[i], *pb = NULL;
+        while (b) {
+            gc_record_t *r = &b->record;
+            if (!(r->flags & GC_BLOCK_MARK)) {      // unmarked
+                gc_bucket_t *nb = b->next;
 
-    gc->young = realloc(gc->young, PRIME_SIZES[0] * sizeof(gc_block_t));
-    gc->youngc = PRIME_SIZES[0];
-    gc->nyoung = 0;
-
-    memset(gc->young, 0, PRIME_SIZES[0] * sizeof(gc_block_t));
-}
-
-static void gc_sweep_young(gc_t *gc) {
-    gc_block_t *frees;
-    size_t freec, i, j, k, nj, nh;
-
-    freec = 0;
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (!gc->young[i].hash)                     continue;
-        if (gc->young[i].flags & GC_BLOCK_MARK)     continue;
-        if (gc->young[i].flags & GC_BLOCK_ROOT)     continue;
-        ++freec;
-    }
-
-    frees = malloc(freec * sizeof(gc_block_t));
-    if (!frees) return;
-
-    i = 0; k = 0;
-    while (i < gc->youngc && gc->nyoung > 0) {
-        if (!gc->young[i].hash ||
-             gc->young[i].flags & GC_BLOCK_MARK ||
-             gc->young[i].flags & GC_BLOCK_ROOT) {
-            ++i;
-            continue;
-        }
-
-        gc->allocs -= gc->young[i].size;
-        frees[k] = gc->young[i];
-        memset(&gc->young[i], 0, sizeof(gc_block_t));
-
-        --gc->nyoung;
-        ++k;
-        
-        j = i;
-        while (1) {
-            nj = (j + 1) % gc->youngc;
-            nh = gc->young[nj].hash;
-            if (nh && gc_probe(nj, nh, gc->youngc) > 0) {
-                memcpy(&gc->young[j], &gc->young[nj], sizeof(gc_block_t));
-                memset(&gc->young[nj], 0, sizeof(gc_block_t));
-                j = nj;
+                // update stats and remove record
+                gc->allocs -= r->size;
+                --gc->size;
+                remove_record(gc, i, pb, b, nb);
+                
+                b = nb;
             } else {
-                break;
+                pb = b;
+                b = b->next;
             }
-        } 
+        }
     }
 
-    for (size_t i = 0; i < freec; ++i) {
-        if (frees[i].dtor)  frees[i].dtor(frees[i].ptr);
-        free(frees[i].ptr);
-    }
-
+    // reset dirty byte counter and unmark
     gc->dirty = 0;
-    free(frees);
-    gc_move_to_old(gc);
-
-    // clear old generation
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash)
-            gc->old[i].flags &= ~GC_BLOCK_MARK;
-    }
-}
-
-static void gc_sweep_all(gc_t *gc) {
-    gc_block_t *frees;
-    size_t freec, i, j, k, nj, nh;
-
-    // young generation
-    freec = 0;
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (!gc->young[i].hash)                     continue;
-        if (gc->young[i].flags & GC_BLOCK_MARK)     continue;
-        if (gc->young[i].flags & GC_BLOCK_ROOT)     continue;
-        ++freec;
-    }
-
-    // old generation
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (!gc->old[i].hash)                     continue;
-        if (gc->old[i].flags & GC_BLOCK_MARK)     continue;
-        if (gc->old[i].flags & GC_BLOCK_ROOT)     continue;
-        ++freec;
-    }
-
-    frees = malloc(freec * sizeof(gc_block_t));
-    if (!frees) return;
-
-    // young generation
-    i = 0; k = 0;
-    while (i < gc->youngc && gc->nyoung > 0) {
-        if (!gc->young[i].hash ||
-             gc->young[i].flags & GC_BLOCK_MARK ||
-             gc->young[i].flags & GC_BLOCK_ROOT) {
-            ++i;
-            continue;
-        }
-
-        gc->allocs -= gc->young[i].size;
-        frees[k] = gc->young[i];
-        memset(&gc->young[i], 0, sizeof(gc_block_t));
-
-        --gc->nyoung;
-        ++k;
-        
-        j = i;
-        while (1) {
-            nj = (j + 1) % gc->youngc;
-            nh = gc->young[nj].hash;
-            if (nh && gc_probe(nj, nh, gc->youngc) > 0) {
-                memcpy(&gc->young[j], &gc->young[nj], sizeof(gc_block_t));
-                memset(&gc->young[nj], 0, sizeof(gc_block_t));
-                j = nj;
-            } else {
-                break;
-            }
-        } 
-    }
-
-    i = 0;
-    while (i < gc->oldc && gc->nold > 0) {
-        if (!gc->old[i].hash ||
-             gc->old[i].flags & GC_BLOCK_MARK ||
-             gc->old[i].flags & GC_BLOCK_ROOT) {
-            ++i;
-            continue;
-        }
-
-        gc->allocs -= gc->old[i].size;
-        frees[k] = gc->old[i];
-        memset(&gc->old[i], 0, sizeof(gc_block_t));
-
-        --gc->nold;
-        ++k;
-        
-        j = i;
-        while (1) {
-            nj = (j + 1) % gc->oldc;
-            nh = gc->old[nj].hash;
-            if (nh && gc_probe(nj, nh, gc->oldc) > 0) {
-                memcpy(&gc->old[j], &gc->old[nj], sizeof(gc_block_t));
-                memset(&gc->old[nj], 0, sizeof(gc_block_t));
-                j = nj;
-            } else {
-                break;
-            }
-        } 
-    }
-
-    for (size_t i = 0; i < freec; ++i) {
-        if (frees[i].dtor)  frees[i].dtor(frees[i].ptr);
-        free(frees[i].ptr);
-    }
-
-    gc->dirty = 0;
-    free(frees);
-    gc_shrink_old_pool(gc);
-    gc_move_to_old(gc);
-
-    // clear old generation
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash)
-            gc->old[i].flags &= ~GC_BLOCK_MARK;
-    }
+    gc_unmark(gc);    
 }
 
 #define gc_collect_if_needed(gc)                        \
 {                                                       \
     if (((gc)->flags & GC_COLLECT) &&                   \
-        ((gc)->dirty > GC_MIN_AUTO_COLLECT_SIZE)) {     \
-        if ((gc)->cycles >= GC_MINOR_PER_MAJOR)         \
-            gc_collect(gc);                             \
-        else                                            \
-            gc_collect_young(gc);                       \
-    }                                                   \
+        ((gc)->dirty > GC_MIN_AUTO_COLLECT_SIZE))       \
+        gc_collect(gc);                                 \
 }
 
 /*************** Interface ******************/
 
-gc_t *gc_create(void *stack) {
+gc_t *
+gc_create(void *stack) {
     gc_t *gc = malloc(sizeof(gc_t));
     gc->stack_bottom = stack;
-    gc->young = calloc(PRIME_SIZES[0], sizeof(gc_block_t));
-    gc->youngc = PRIME_SIZES[0];
-    gc->nyoung = 0;
-    gc->old = calloc(PRIME_SIZES[0], sizeof(gc_block_t));
-    gc->oldc = PRIME_SIZES[0];
-    gc->nold = 0;
-    gc->allocs = 0;
+    gc->alloc_ptr = &bucket_sizes[0];
+    gc->alloc = *gc->alloc_ptr;
+    gc->buckets = (gc_bucket_t **) calloc(gc->alloc, sizeof(gc_bucket_t*));
+    gc->size = 0;
     gc->dirty = 0;
-    gc->cycles = 0;
+    gc->allocs = 0;
     gc->flags = GC_COLLECT;
 
     return gc;
 }
 
-void gc_destroy(gc_t* gc) {
-    // unmark young generation
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].flags & GC_BLOCK_ROOT)
-            gc->young[i].flags &= ~GC_BLOCK_ROOT;
-    }
+void
+gc_destroy(gc_t* gc) {
+    // unmark and sweep
+    gc_unmark(gc);
+    gc_sweep(gc);
 
-    // unmark old generation
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].flags & GC_BLOCK_ROOT)
-            gc->old[i].flags &= ~GC_BLOCK_ROOT;
-    }
-
-    gc_sweep_all(gc);
-    free(gc->young);
-    free(gc->old);
+    // free up gc structure
+    free(gc->buckets);
     free(gc);
 }
 
-void gc_pause(gc_t *gc)
-{
+void
+gc_pause(gc_t *gc) {
     gc->flags &= ~GC_COLLECT;
 }
 
-void gc_resume(gc_t *gc)
-{
+void
+gc_resume(gc_t *gc){
     gc->flags |= GC_COLLECT;
 }
 
-void gc_add(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk) {
-    gc_resize_if_needed(gc); 
-    gc_add_young_pool(gc, ptr, size, dtor, mrk, 1, 0);
+void
+gc_add(gc_t *gc,
+       void *ptr,
+       size_t size,
+       gc_dtor_t dtor,
+       gc_mark_t mrk) {
+    // resize and add
+    gc_resize_if_needed(gc);
+    add_record(gc, ptr, size, dtor, mrk, 0);
+
+    // update stats
+    gc->dirty += size;
+    gc->allocs += size;
+    ++gc->size;
+
+    // collect if needed
     gc_collect_if_needed(gc);
 }
 
-void gc_remove(gc_t *gc, void *ptr, int destroy) {
-    size_t h, j, i, nj, nh;
+void
+gc_remove(gc_t *gc,
+          void *ptr,
+          int destroy) {
+    gc_bucket_t *b, *pb;
+    size_t i;
 
-    // try younger generatiom
-    i = gc_hash(ptr) % gc->youngc;
-    j = 0;
-    while (1) {
-        h = gc->young[i].hash;
-        if (!h || j > gc_probe(i, h, gc->youngc))
-            break;
+    i = gc_hash(ptr) % gc->alloc;
+    b = gc->buckets[i];
+    pb = NULL;
+    while (b) {
+        gc_record_t *r = &b->record;
+        if (ptr == r->ptr) {    // found correct record
+            // update stats
+            gc->allocs -= r->size;
+            --gc->size;
 
-        if (gc->young[i].ptr == ptr) {
-            gc->allocs -= gc->young[i].size;
-            if (destroy) {
-                if (gc->young[i].dtor)  gc->young[i].dtor(gc->young[i].ptr);
-                free(gc->young[i].ptr);
-            }
-
-            memset(&gc->young[i], 0, sizeof(gc_block_t));
-            j = i;
-            while (1) {
-                nj = (j + 1) % gc->youngc;
-                nh = gc->young[nj].hash;
-                if (nh && gc_probe(nj, nh, gc->youngc) > 0) {
-                    memcpy(&gc->young[j], &gc->young[nj], sizeof(gc_block_t));
-                    memset(&gc->young[nj], 0, sizeof(gc_block_t));
-                    j = nj;
-                } else {
-                    break;
-                }
-            }
-
-            --gc->nyoung;
+            // destroy resources as needed
+            if (destroy)    remove_record(gc, i, pb, b, b->next);
             return;
         }
 
-        i = (i + 1) % gc->youngc;
-        ++j;
+        b = b->next;
     }
+}
 
-    // try older generatiom
-    i = gc_hash(ptr) % gc->oldc;
-    j = 0;
-    while (1) {
-        h = gc->old[i].hash;
-        if (!h || j > gc_probe(i, h, gc->oldc))
-            return;
-
-        if (gc->old[i].ptr == ptr) {
-            gc->allocs -= gc->old[i].size;
-            if (destroy) {
-                if (gc->old[i].dtor)  gc->old[i].dtor(gc->old[i].ptr);
-                free(gc->old[i].ptr);
-            }
-
-            memset(&gc->old[i], 0, sizeof(gc_block_t));
-            j = i;
-            while (1) {
-                nj = (j + 1) % gc->oldc;
-                nh = gc->old[nj].hash;
-                if (nh && gc_probe(nj, nh, gc->oldc) > 0) {
-                    memcpy(&gc->old[j], &gc->old[nj], sizeof(gc_block_t));
-                    memset(&gc->old[nj], 0, sizeof(gc_block_t));
-                    j = nj;
-                } else {
-                    break;
-                }
-            }
-
-            --gc->nold;
-            return;
+gc_record_t *
+gc_get_record(gc_t *gc,
+              void *ptr) {
+    size_t i = gc_hash(ptr) % gc->alloc;
+    for (gc_bucket_t *b = gc->buckets[i]; b; b = b->next) {
+        if (ptr == b->record.ptr) {
+            return &b->record;
         }
-
-        i = (i + 1) % gc->oldc;
-        ++j;
     }
+
+    return NULL;
 }
 
-gc_block_t *gc_get_block(gc_t *gc, void *ptr) {
-    size_t h, i, j;
-
-    // try young generation
-    i = gc_hash(ptr) % gc->youngc;
-    j = 0;
-    while (1) {
-        h = gc->young[i].hash;
-        if (!h || j > gc_probe(i, h, gc->youngc))
-            break;
-
-        if (gc->young[i].ptr == ptr)
-            return &gc->young[i];
-
-        i = (i + 1) % gc->youngc;
-        ++j;
-    }
-
-    // try old generation
-    i = gc_hash(ptr) % gc->oldc;
-    j = 0;
-    while (1) {
-        h = gc->old[i].hash;
-        if (!h || j > gc_probe(i, h, gc->oldc))
-            return NULL;
-
-        if (gc->old[i].ptr == ptr)
-            return &gc->old[i];
-
-        i = (i + 1) % gc->oldc;
-        ++j;
-    }
-}
-
-void gc_update_block(gc_t *gc, gc_block_t *block, size_t size, gc_dtor_t dtor, gc_mark_t mrk) {
-    gc->allocs -= block->size;
+void
+gc_update_record(gc_t *gc,
+                 gc_record_t *record,
+                 size_t size,
+                 gc_dtor_t dtor,
+                 gc_mark_t mrk) {
+    gc->allocs -= record->size;
     gc->allocs += size;
 
-    block->size = size;
-    block->dtor = dtor;
-    block->mrk = mrk;
+    record->size = size;
+    record->dtor = dtor;
+    record->mrk = mrk;
 }
 
-void gc_collect(gc_t *gc) {
-    gc_mark_all(gc);
-    gc_sweep_all(gc);
-    gc->cycles = 0;
+void
+gc_collect(gc_t *gc) {
+    gc_mark(gc);
+    gc_sweep(gc);
 }
 
-void gc_collect_young(gc_t *gc) {
-    gc_mark_young(gc);
-    gc_sweep_young(gc);
-    ++gc->cycles;
+void
+gc_register_dtor(gc_t *gc,
+                 void *ptr,
+                 gc_dtor_t dtor) {
+    gc_record_t *r = gc_get_record(gc, ptr);
+    if (r)  r->dtor = dtor;
 }
 
-void gc_register_dtor(gc_t *gc, void *ptr, gc_dtor_t dtor) {
-    gc_block_t *block;
-
-    block = gc_get_block(gc, ptr);
-    if (block)  block->dtor = dtor;
+void
+gc_register_mrk(gc_t *gc,
+                void *ptr,
+                gc_mark_t mrk) {
+    gc_record_t *r = gc_get_record(gc, ptr);
+    if (r)  r->mrk = mrk;
 }
 
-void gc_register_mrk(gc_t *gc, void *ptr, gc_mark_t mrk) {
-    gc_block_t *block;
-
-    block = gc_get_block(gc, ptr);
-    if (block)  block->mrk = mrk;
+void
+gc_register_root(gc_t *gc,
+                 void *ptr) {
+    gc_record_t *r = gc_get_record(gc, ptr);
+    if (r)  r->flags |= GC_BLOCK_ROOT;
 }
 
-void gc_register_root(gc_t *gc, void *ptr) {
-    gc_block_t *block;
-
-    block = gc_get_block(gc, ptr);
-    if (block)  block->flags |= GC_BLOCK_ROOT;
-}
-
-size_t gc_get_allocated(gc_t *gc) {
+size_t
+gc_get_allocated(gc_t *gc) {
     return gc->allocs;
 }
 
-size_t gc_get_reachable(gc_t *gc) {
+size_t
+gc_get_reachable(gc_t *gc) {
     size_t total = 0;
 
-    gc_mark_all(gc);
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash && gc->young[i].flags & GC_BLOCK_MARK)
-            total += gc->young[i].size;
-    }
-
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash && gc->old[i].flags & GC_BLOCK_MARK)
-            total += gc->old[i].size;
+    gc_mark(gc);
+    for (size_t i = 0; i < gc->alloc; ++i) {
+        for (gc_bucket_t *b = gc->buckets[i]; b; b = b->next) {
+            gc_record_t *r = &b->record;
+            if (r->flags & GC_BLOCK_MARK)
+                total += r->size;
+        }
     }
 
     gc_unmark(gc);
     return total;
 }
 
-size_t gc_get_collectable(gc_t *gc) {
-    size_t total = 0;
-
-    gc_mark_all(gc);
-    for (size_t i = 0; i < gc->youngc; ++i) {
-        if (gc->young[i].hash && !(gc->young[i].flags & GC_BLOCK_MARK))
-            total += gc->young[i].size;
-    }
-
-    for (size_t i = 0; i < gc->oldc; ++i) {
-        if (gc->old[i].hash && !(gc->old[i].flags & GC_BLOCK_MARK))
-            total += gc->old[i].size;
-    }
-
-    gc_unmark(gc);
-    return total;
+size_t
+gc_get_collectable(gc_t *gc) {
+    return (gc->alloc - gc_get_reachable(gc));
 }
 
 // Signals to mark phase not to descend

--- a/src/gc/gc-impl.c
+++ b/src/gc/gc-impl.c
@@ -83,21 +83,6 @@ insert_record(gc_t *gc,
     gc->buckets[i] = r;
 }
 
-// Creates a new record.
-static gc_record_t *
-make_record(void *ptr,
-            size_t size,
-            gc_dtor_t dtor,
-            gc_mark_t mrk) {
-    gc_record_t *r = (gc_record_t *) malloc(sizeof(gc_record_t));
-    r->next = NULL;
-    r->size = size;
-    r->dtor = dtor;
-    r->mrk = mrk;
-
-    return r;
-}
-
 static void
 gc_resize(gc_t *gc,
           size_t *alloc_ptr) {
@@ -301,25 +286,6 @@ gc_resume(gc_t *gc){
 }
 
 void
-gc_add(gc_t *gc,
-       void *ptr,
-       size_t size,
-       gc_dtor_t dtor,
-       gc_mark_t mrk) {
-    gc_record_t *r;
-
-    // resize and add
-    gc_expand_if_needed(gc);
-    r = make_record(ptr, size, dtor, mrk);
-    insert_record(gc, r);
-
-    // update stats
-    gc->dirty += size;
-    gc->allocs += size;
-    ++gc->size;
-}
-
-void
 gc_remove(gc_t *gc,
           void *ptr,
           int destroy) {
@@ -445,20 +411,6 @@ gc_add_record(gc_t *gc,
     gc->dirty += record->size;
     gc->allocs += record->size;
     ++gc->size;
-}
-
-void
-gc_update_record(gc_t *gc,
-                 gc_record_t *record,
-                 size_t size,
-                 gc_dtor_t dtor,
-                 gc_mark_t mrk) {
-    gc->allocs -= record->size;
-    gc->allocs += size;
-
-    record->size = size;
-    record->dtor = dtor;
-    record->mrk = mrk;
 }
 
 void

--- a/src/gc/gc-impl.h
+++ b/src/gc/gc-impl.h
@@ -1,5 +1,5 @@
-#ifndef _MINIM_GC_H_
-#define _MINIM_GC_H_
+#ifndef _MINIM_GC_IMPL_H_
+#define _MINIM_GC_IMPL_H_
 
 #include <limits.h>
 #include <stddef.h>
@@ -14,7 +14,6 @@
 #define GC_MIN_AUTO_COLLECT_SIZE     (8 * 1024 * 1024)
 #define GC_TABLE_LOAD_FACTOR         0.5
 #define GC_MINOR_PER_MAJOR           15
-#define GC_CUSTOM_MARKER_MODE        2
 
 /* Heap heuristic */
 #if defined (_WIN32) || defined (_WIN64)
@@ -34,11 +33,10 @@ void gc_resume(gc_t *gc);
 void gc_add(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 void gc_remove(gc_t *gc, void *ptr, int destroy);
 
-gc_block_t *gc_get_block(gc_t *gc, void *ptr);
-void gc_update_block(gc_t *gc, gc_block_t *block, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
+gc_record_t *gc_get_record(gc_t *gc, void *ptr);
+void gc_update_record(gc_t *gc, gc_record_t *record, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 
 void gc_collect(gc_t *gc);
-void gc_collect_young(gc_t *gc);
 
 void gc_register_dtor(gc_t *gc, void *ptr, gc_dtor_t dtor);
 void gc_register_mrk(gc_t *gc, void *ptr, gc_mark_t mrk);

--- a/src/gc/gc-impl.h
+++ b/src/gc/gc-impl.h
@@ -12,7 +12,7 @@
 
 /* GC Parameters */
 #define GC_MIN_AUTO_COLLECT_SIZE     (8 * 1024 * 1024)
-#define GC_TABLE_LOAD_FACTOR         0.5
+#define GC_TABLE_LOAD_FACTOR         0.75
 #define GC_MINOR_PER_MAJOR           15
 
 /* Heap heuristic */

--- a/src/gc/gc-impl.h
+++ b/src/gc/gc-impl.h
@@ -33,7 +33,12 @@ void gc_resume(gc_t *gc);
 void gc_add(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 void gc_remove(gc_t *gc, void *ptr, int destroy);
 
+gc_record_t *gc_alloc_record(gc_t *gc, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
+gc_record_t *gc_calloc_record(gc_t *gc, size_t nmem, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
+gc_record_t *gc_realloc_record(gc_t *gc, gc_record_t *r, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
+
 gc_record_t *gc_get_record(gc_t *gc, void *ptr);
+void gc_add_record(gc_t *gc, gc_record_t *record);
 void gc_update_record(gc_t *gc, gc_record_t *record, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 
 void gc_collect(gc_t *gc);
@@ -45,5 +50,12 @@ void gc_register_root(gc_t *gc, void *ptr);
 size_t gc_get_allocated(gc_t *gc);
 size_t gc_get_reachable(gc_t *gc);
 size_t gc_get_collectable(gc_t *gc);
+
+#define gc_collect_if_needed(gc)                        \
+{                                                       \
+    if (((gc)->flags & GC_COLLECT) &&                   \
+        ((gc)->dirty > GC_MIN_AUTO_COLLECT_SIZE))       \
+        gc_collect(gc);                                 \
+}
 
 #endif

--- a/src/gc/gc-impl.h
+++ b/src/gc/gc-impl.h
@@ -30,7 +30,6 @@ void gc_destroy(gc_t* gc);
 void gc_pause(gc_t *gc);
 void gc_resume(gc_t *gc);
 
-void gc_add(gc_t *gc, void *ptr, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 void gc_remove(gc_t *gc, void *ptr, int destroy);
 
 gc_record_t *gc_alloc_record(gc_t *gc, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
@@ -39,7 +38,6 @@ gc_record_t *gc_realloc_record(gc_t *gc, gc_record_t *r, size_t size, gc_dtor_t 
 
 gc_record_t *gc_get_record(gc_t *gc, void *ptr);
 void gc_add_record(gc_t *gc, gc_record_t *record);
-void gc_update_record(gc_t *gc, gc_record_t *record, size_t size, gc_dtor_t dtor, gc_mark_t mrk);
 
 void gc_collect(gc_t *gc);
 

--- a/src/gc/gc-types.h
+++ b/src/gc/gc-types.h
@@ -22,7 +22,6 @@ typedef struct gc_record_t {
     size_t size;
     gc_dtor_t dtor;
     gc_mark_t mrk;
-    void *ptr;
 } gc_record_t;
 
 /* Main GC type */
@@ -37,8 +36,10 @@ typedef struct gc_t {
 
 /* Accessors */
 
-#define gc_record_next(r)       ((void *) (((uintptr_t) (r)->next) & ~0x3))
-#define gc_record_flags(r)      (((uintptr_t) (r)->next) & 0x3)
+#define gc_record_ptr(r)            ((void *) (((uintptr_t) (r)) + sizeof(gc_record_t)))
+#define gc_record_next(r)           ((void *) (((uintptr_t) (r)->next) & ~0x3))
+#define gc_record_flags(r)          (((uintptr_t) (r)->next) & 0x3)
+#define gc_record_alloc_size(r)     ((r)->size + sizeof(gc_record_t))
 
 #define gc_load(gc)     (((double) (gc)->size) / ((double) (gc)->alloc))
 #define gc_hash(p)      (((size_t) (p)) >> 3)

--- a/src/gc/gc-types.h
+++ b/src/gc/gc-types.h
@@ -14,23 +14,28 @@ typedef void (*gc_dtor_t)(void*);
 /* Marking signature */
 typedef void (*gc_mark_t)(void*,void*,void*);
 
-/* GC block type */
-typedef struct gc_block_t {
+/* GC record type */
+typedef struct gc_record_t {
     void *ptr;
     gc_dtor_t dtor;
     gc_mark_t mrk;
     size_t size, hash;
     uint8_t flags;
-} gc_block_t;
+} gc_record_t;
+
+/* GC bucket type */
+typedef struct gc_bucket_t {
+    gc_record_t record;
+    struct gc_bucket_t *next;
+} gc_bucket_t;
 
 /* Main GC type */
 typedef struct gc_t {
-    gc_block_t *young, *old;
+    gc_bucket_t **buckets;
     void *stack_bottom;
-    size_t youngc, nyoung;
-    size_t oldc, nold;
+    size_t *alloc_ptr;
+    size_t alloc, size;
     size_t allocs, dirty;
-    size_t cycles;
     uint8_t flags;
 } gc_t;
 

--- a/src/gc/gc-types.h
+++ b/src/gc/gc-types.h
@@ -1,9 +1,11 @@
 #ifndef _MINIM_GC_TYPES_H_
 #define _MINIM_GC_TYPES_H_
 
+#include <stdint.h>
+
 /* Block flag */
-#define GC_BLOCK_MARK       0x1
-#define GC_BLOCK_ROOT       0x2
+#define GC_RECORD_MARK       0x1
+#define GC_RECORD_ROOT       0x2
 
 /* GC flag */
 #define GC_COLLECT          0x1
@@ -14,29 +16,47 @@ typedef void (*gc_dtor_t)(void*);
 /* Marking signature */
 typedef void (*gc_mark_t)(void*,void*,void*);
 
-/* GC record type */
+/* GC bucket type */
 typedef struct gc_record_t {
-    void *ptr;
+    struct gc_record_t *next;
+    size_t size;
     gc_dtor_t dtor;
     gc_mark_t mrk;
-    size_t size, hash;
-    uint8_t flags;
+    void *ptr;
 } gc_record_t;
-
-/* GC bucket type */
-typedef struct gc_bucket_t {
-    gc_record_t record;
-    struct gc_bucket_t *next;
-} gc_bucket_t;
 
 /* Main GC type */
 typedef struct gc_t {
-    gc_bucket_t **buckets;
+    gc_record_t **buckets;
     void *stack_bottom;
     size_t *alloc_ptr;
     size_t alloc, size;
     size_t allocs, dirty;
     uint8_t flags;
 } gc_t;
+
+/* Accessors */
+
+#define gc_record_next(r)       ((void *) (((uintptr_t) (r)->next) & ~0x3))
+#define gc_record_flags(r)      (((uintptr_t) (r)->next) & 0x3)
+
+#define gc_load(gc)     (((double) (gc)->size) / ((double) (gc)->alloc))
+#define gc_hash(p)      (((size_t) (p)) >> 3)
+
+/* Predicates */
+
+#define gc_record_markp(r)      (gc_record_flags(r) & GC_RECORD_MARK)
+#define gc_record_rootp(r)      (gc_record_flags(r) & GC_RECORD_ROOT)
+
+/* Setters */
+
+#define gc_record_mark_set(r)       (*((uintptr_t*) &((r)->next)) |= GC_RECORD_MARK)
+#define gc_record_mark_unset(r)     (*((uintptr_t*) &((r)->next)) &= ~GC_RECORD_MARK)
+
+#define gc_record_root_set(r)       (*((uintptr_t*) &((r)->next)) |= GC_RECORD_ROOT)
+#define gc_record_root_unset(r)     (*((uintptr_t*) &((r)->next)) &= ~GC_RECORD_ROOT)
+
+#define gc_record_next_set(r, n)    \
+    ((r)->next = (void *) (((uintptr_t) (n)) | ((uintptr_t) gc_record_flags(r))))
 
 #endif

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -25,72 +25,59 @@ void GC_resume() {
 void *GC_alloc_opt(size_t size,
                    void (*dtor)(void*),
                    void (*mrk)(void (void*, void*), void*, void*)) {
-    void *ptr;
+    gc_record_t *r;
+
+    // collect if needed
+    gc_collect_if_needed(main_gc);
     
-    ptr = malloc(size);
-    if (ptr == NULL)
-    {
-        gc_collect(main_gc);
-        ptr = malloc(size);
-        if (ptr == NULL)
-            return NULL;
-    }
-    
-    gc_add(main_gc, ptr, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
-    return ptr;
+    // allocate
+    r = gc_alloc_record(main_gc, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
+    gc_add_record(main_gc, r);
+    return r->ptr;
 }
 
 void *GC_calloc_opt(size_t nmem,
                     size_t size,
                     void (*dtor)(void*),
                     void (*mrk)(void (void*, void*), void*, void*)) {
-    void *ptr;
-    
-    ptr = calloc(nmem, size);
-    if (ptr == NULL)
-    {
-        gc_collect(main_gc);
-        ptr = calloc(nmem, size);
-        if (ptr == NULL)
-            return NULL;
-    }
+    gc_record_t *r;
 
-    gc_add(main_gc, ptr, nmem * size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
-    return ptr;
+    // collect if needed
+    gc_collect_if_needed(main_gc);
+    
+    // allocate
+    r = gc_calloc_record(main_gc, nmem, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
+    gc_add_record(main_gc, r);
+    return r->ptr;
 }
 
 void *GC_realloc_opt(void *ptr,
                      size_t size,
                      void (*dtor)(void*),
                      void (*mrk)(void (void*, void*), void*, void*)) {
-    gc_record_t *rec;
-    void *ptr2;
+    gc_record_t *rec, *rec2;
 
-    if (!size) {
+    // zero size
+    if (size == 0) {
         gc_remove(main_gc, ptr, 1);
         return NULL;
     }
-    
-    ptr2 = realloc(ptr, size);
-    if (ptr2 == NULL) {
-        gc_remove(main_gc, ptr, 0);
-        return NULL;
-    }
 
-    if (ptr == NULL) {
-        gc_add(main_gc, ptr2, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
-        return ptr2;
-    }
+    // no pointer
+    if (ptr == NULL)
+        return GC_alloc_opt(size, dtor, mrk);
 
     rec = gc_get_record(main_gc, ptr);
     if (rec) {
-        if (ptr == ptr2) {
+        rec2 = gc_realloc_record(main_gc, rec, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
+        if (rec->ptr == rec2->ptr) {
             gc_update_record(main_gc, rec, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
-            return ptr;
+            free(rec2);
+            return rec->ptr;
         } else {
             gc_remove(main_gc, ptr, 0);
-            gc_add(main_gc, ptr2, size, (gc_dtor_t) dtor, (gc_mark_t) mrk);
-            return ptr2;
+            gc_add_record(main_gc, rec2);
+            return rec2->ptr;
         }
     } else {
         return GC_alloc_opt(size, dtor, mrk);

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -22,6 +22,30 @@ void GC_resume() {
     gc_resume(main_gc);
 }
 
+void *GC_alloc(size_t size) {
+    return GC_alloc_opt(size, NULL, NULL);
+}
+
+void *GC_calloc(size_t nmem, size_t size) {
+    return GC_calloc_opt(nmem, size, NULL, NULL);
+}
+
+void *GC_realloc(void *ptr, size_t size) {
+    return GC_realloc_opt(ptr, size, NULL, NULL);
+}
+
+void *GC_alloc_atomic(size_t size) {
+    return GC_alloc_opt(size, NULL, GC_atomic_mrk);
+}
+
+void *GC_calloc_atomic(size_t nmem, size_t size) {
+    return GC_calloc_opt(nmem, size, NULL, GC_atomic_mrk);
+}
+
+void *GC_realloc_atomic(void *ptr, size_t size) {
+    return GC_realloc_opt(ptr, size, NULL, GC_atomic_mrk);
+}
+
 void *GC_alloc_opt(size_t size,
                    void (*dtor)(void*),
                    void (*mrk)(void (void*, void*), void*, void*)) {

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -38,7 +38,6 @@ void GC_free(void *ptr);
 
 /* Manually run garbage collection */
 void GC_collect();
-void GC_collect_minor();
 
 /* Register destructor and marker functions for objects.  */
 void GC_register_dtor(void *ptr, void (*func)(void*));

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -17,15 +17,15 @@ void GC_pause();
 void GC_resume();
 
 /* GC equivalent of malloc(), calloc(), and realloc() */
-#define GC_alloc(size)              GC_alloc_opt(size, NULL, NULL)
-#define GC_calloc(nmem, size)       GC_calloc_opt(nmem, size, NULL, NULL)
-#define GC_realloc(ptr, size)       GC_realloc_opt(ptr, size, NULL, NULL)
+void *GC_alloc(size_t size);
+void *GC_calloc(size_t nmem, size_t size);
+void *GC_realloc(void *ptr, size_t size);
 
 /* GC equivalent of malloc(), calloc(), and realloc() except the data
    contains no pointer data. */
-#define GC_alloc_atomic(size)           GC_alloc_opt(size, NULL, GC_atomic_mrk)
-#define GC_calloc_atomic(nmem, size)    GC_calloc_opt(nmem, size, NULL, GC_atomic_mrk)
-#define GC_realloc_atomic(ptr, size)    GC_realloc_opt(ptr, size, NULL, GC_atomic_mrk)
+void *GC_alloc_atomic(size_t size);
+void *GC_calloc_atomic(size_t nmem, size_t size);
+void *GC_realloc_atomic(void *ptr, size_t size);
 
 /* GC equivalent of malloc(), calloc(), and realloc() except with explicit
    destructor and marker functions */


### PR DESCRIPTION
This PR overhauls the current garbage collector with a simpler and faster design. The garbage collector now allocates a single block per request, containing a header and the pointer contents itself. The hash table tracking all of this is now implemented with separate chaining rather than open addressing. Overall, there is a 20 - 40% speed up.