### PR TITLE
Fix expander

### DIFF
--- a/src/boot/Makefile
+++ b/src/boot/Makefile
@@ -38,6 +38,8 @@ profile:
 
 test: $(CONFIG) $(BUILD_DIR)/test-prims;
 	$(BUILD_DIR)/test-prims
+	$(MINIM) $(TEST_DIR)/case-lambda.min
+	$(MINIM) $(TEST_DIR)/case.min
 	$(MINIM) $(TEST_DIR)/stxcase.min
 
 clean:

--- a/src/boot/c/io.c
+++ b/src/boot/c/io.c
@@ -265,6 +265,10 @@ loop:
                     c = '\t';
                 } else if (c == '\\') {
                     c = '\\';
+                } else if (c == '\'') {
+                    c = '\'';
+                } else if (c == '\"') {
+                    c = '\"';
                 } else {
                     fprintf(stderr, "unknown escape character: %c\n", c);
                     exit(1);

--- a/src/boot/lib/base.min
+++ b/src/boot/lib/base.min
@@ -14,6 +14,7 @@
         "private/when-unless.min")
 
 (export (all "private/and-or.min")
+        (all "private/case.min")
         (all "private/cond.min")
         (all "private/define.min")
         (all "private/let.min")
@@ -22,3 +23,9 @@
         (all "private/stxcase-extra.min")
         (all "private/template.min")
         (all "private/when-unless.min"))
+
+
+(begin
+  (define x 1)
+  (define y 2)
+  (+ x y))

--- a/src/boot/lib/base.min
+++ b/src/boot/lib/base.min
@@ -3,6 +3,7 @@
 ;;;
 
 (import "private/and-or.min"
+        "private/case.min"
         "private/cond.min"
         "private/define.min"
         "private/let.min"

--- a/src/boot/lib/base.min
+++ b/src/boot/lib/base.min
@@ -23,9 +23,3 @@
         (all "private/stxcase-extra.min")
         (all "private/template.min")
         (all "private/when-unless.min"))
-
-
-(begin
-  (define x 1)
-  (define y 2)
-  (+ x y))

--- a/src/boot/lib/private/case.min
+++ b/src/boot/lib/private/case.min
@@ -3,9 +3,10 @@
 ;;;
 
 (import "and-or.min" "define.min" "let.min" "stx.min"
-        "stxcase.min" "template.min" "when-unless.min")
+        "stxcase.min" "stxcase-extra.min" "template.min"
+        "when-unless.min")
 
-(export case)
+(export case case-lambda)
 
 (define-syntax (case stx)
   (syntax-case stx (else)
@@ -54,3 +55,44 @@
      #'(equal? v 'k)]
     [(_ v (k ks ...))
      #'(if (equal? v 'k) #t (case/test v (ks ...)))]))
+
+(define-syntax (case-lambda stx)
+  (syntax-case stx ()
+    [(_ (a e es ...) (a2 e2 e2s ...) ...)
+     #'(lambda args
+         (let-values ([(l) (length args)])
+           (case-lambda/clause args l (a e es ...) (a2 e2 e2s ...) ...)))]
+    [(_ cls ...)
+     (let loop ([clauses (syntax->list #'(cls ...))])
+       (unless (null? clauses)
+         (let ([clause (car clauses)])
+           (syntax-case clause ()
+             [((_ ...) _ ...)
+              (loop (cdr clauses))]
+             [((_ ...) . _)
+              (syntax-error 'case-lambda "missing body after formals" stx clause)]
+             [_
+              (syntax-error 'case-lambda "ill-formed clause" stx clause)]))))]
+    [_ (syntax-error 'case-lambda "bad syntax" stx)]))
+
+(define-syntax case-lambda/clause
+  (syntax-rules ()
+   [(_ args l ((a ...) e ...) clause ...)
+    (if (= l (length '(a ...)))
+        (apply (lambda (a ...) e ...) args)
+        (case-lambda/clause args l clause ...))]
+   [(_ args l ((a . rest) e ...) clause ...)
+    (case-lambda/improper args l 1 (a . rest) (rest e ...) clause ...)]
+   [(_ args l (a e ...) clause ...)
+    (let-values ([(a) args]) e ...)]
+   [(_ args l)
+    (error "arity mismatch: given ~a" l)]))
+
+(define-syntax case-lambda/improper
+  (syntax-rules ()
+   [(_ args l k al ((a . rest) e ...) clause ...)
+    (case-lambda/improper args l (+ k 1) al (rest e ...) clause ...)]
+   [(_ args l k al (rest e ...) clause ...)
+    (if (>= l k)
+        (apply (lambda al e ...) args)
+        (case-lambda/clause args l clause ...))]))

--- a/src/boot/lib/private/case.min
+++ b/src/boot/lib/private/case.min
@@ -1,0 +1,56 @@
+;;;   
+;;; 'case'
+;;;
+
+(import "and-or.min" "define.min" "let.min" "stx.min"
+        "stxcase.min" "template.min" "when-unless.min")
+
+(export case)
+
+(define-syntax (case stx)
+  (syntax-case stx (else)
+    [(_ v)                                              ; empty case
+     #'(begin v (void))]
+    [(_ v [else e es ...])                              ; else case
+     #'(begin v (let-values () e es ...))]
+    [(_ v [(k ...) e es ...] ...)                       ; missing else
+     #'(case v [(k ...) e es ...] ... [else (void)])]
+    [(_ v [(k ...) e es ...] ... [else x xs ...])       ; general case
+     #'(let ([tmp v]) (case/else tmp [(k ...) e es ...] ... [else x xs ...]))]
+
+    [(_ v cls ...)                                      ; error cases
+     (let loop ([clauses (syntax->list #'(cls ...))])
+       (unless (null? clauses)
+         (let ([clause (car clauses)])
+           (syntax-case clause ()
+             [((_ ...) _ _ ...)
+              (loop (cdr clauses))]
+             [((_ ...) . _)
+              (syntax-case clause ()
+                [(_) (syntax-error 'case "missing expression after datum sequence" stx clause)]
+                [_ (syntax-error 'case "not a datum sequence" stx clause)])]
+             [(_ . _) (syntax-error 'case "not a datum sequence" stx clause)]
+             [_ (syntax-error 'case "ill-formed clause" stx clause)]))))]
+    [_ (syntax-error 'case "bad syntax" stx)]))
+
+(define-syntax (case/else stx)
+  (syntax-case stx (else)
+    [(_ v [(k ...) es ...] [else xs ...])
+     #'(if (case/test v (k ...))
+           (let-values () es ...)
+           (let-values () xs ...))]
+    [(_ v [(k ...) es ...] rest ... [else xs ...])
+     #'(if (case/test v (k ...))
+           (let-values () es ...)
+           (case/else v rest ... [else xs ...]))]
+    [(_ v [else xs ...])
+     #'(let-values () xs ...)]))
+  
+(define-syntax (case/test stx)
+  (syntax-case stx ()
+    [(_ v ())
+     #'#f]
+    [(_ v (k))
+     #'(equal? v 'k)]
+    [(_ v (k ks ...))
+     #'(if (equal? v 'k) #t (case/test v (ks ...)))]))

--- a/src/boot/lib/private/stxcase.min
+++ b/src/boot/lib/private/stxcase.min
@@ -238,45 +238,63 @@
                               ; variable =>
                               ;  bind one variable
                               (list
-                                (quote-syntax cons/#f)
-                                  (list
-                                    (quote-syntax stx-car)
-                                    (quote-syntax e))
-                                  (loop tail-pat (+ idx 1)
-                                        (datum->syntax
-                                          (list
-                                            (quote-syntax stx-cdr)
-                                            (quote-syntax e)))))]
+                                (quote-syntax if)
+                                (list
+                                  (quote-syntax stx-pair?)
+                                  (quote-syntax e))
+                                (list
+                                  (quote-syntax cons/#f)
+                                    (list
+                                      (quote-syntax stx-car)
+                                      (quote-syntax e))
+                                    (loop tail-pat (+ idx 1)
+                                          (datum->syntax
+                                            (list
+                                              (quote-syntax stx-cdr)
+                                              (quote-syntax e)))))
+                                #f)]
                              [(stx-pair? head-pat)
                               ; subpattern =>
                               ;  recurse and append
                               (list
-                                (quote-syntax append/#f)
-                                (gen-match/expr head-pat
-                                                (datum->syntax
-                                                  (list
-                                                    (quote-syntax stx-car)
-                                                    (quote-syntax e))))
-                                (loop tail-pat (+ idx 1)
-                                      (datum->syntax
-                                        (list
-                                          (quote-syntax stx-cdr)
-                                          (quote-syntax e)))))]
+                                (quote-syntax if)
+                                (list
+                                  (quote-syntax stx-pair?)
+                                  (quote-syntax e))
+                                (list
+                                  (quote-syntax append/#f)
+                                  (gen-match/expr head-pat
+                                                  (datum->syntax
+                                                    (list
+                                                      (quote-syntax stx-car)
+                                                      (quote-syntax e))))
+                                  (loop tail-pat (+ idx 1)
+                                        (datum->syntax
+                                          (list
+                                            (quote-syntax stx-cdr)
+                                            (quote-syntax e)))))
+                                #f)]
                              [else
                               ; datum =>
                               ;  just check if it matches
                               (list
                                 (quote-syntax if)
-                                (gen-match/expr head-pat
-                                                (datum->syntax
-                                                  (list
-                                                    (quote-syntax stx-car)
-                                                    (quote-syntax e))))
-                                (loop tail-pat (+ idx 1)
-                                      (datum->syntax
-                                        (list
-                                          (quote-syntax stx-cdr)
-                                          (quote-syntax e))))
+                                (list
+                                  (quote-syntax stx-pair?)
+                                  (quote-syntax e))
+                                (list
+                                  (quote-syntax if)
+                                  (gen-match/expr head-pat
+                                                  (datum->syntax
+                                                    (list
+                                                      (quote-syntax stx-car)
+                                                      (quote-syntax e))))
+                                  (loop tail-pat (+ idx 1)
+                                        (datum->syntax
+                                          (list
+                                            (quote-syntax stx-cdr)
+                                            (quote-syntax e))))
+                                  #f)
                                 #f)]))
                          arg))]))]
                [else

--- a/src/boot/lib/private/stxcase.min
+++ b/src/boot/lib/private/stxcase.min
@@ -215,7 +215,7 @@
                                         (quote-syntax tmp)
                                         (list
                                           (quote-syntax apply)
-                                          (quote-syntax map)
+                                          (quote-syntax map/#f)
                                           (quote-syntax list)
                                           (quote-syntax tmp)))
                                       #f)))

--- a/src/boot/s/base.min
+++ b/src/boot/s/base.min
@@ -167,3 +167,30 @@
               [(pair? datum) (cons (loop2 (car datum)) (loop2 (cdr datum)))]
               [else datum]))))
       (error 'syntax->datum "expected syntax?" stx)))
+
+(define (stx-pair? stx)
+  (if (pair? stx)
+      #t
+      (if (syntax? stx)
+          (pair? (syntax-e stx))
+          #f)))
+
+(define (stx-null? stx)
+  (if (null? stx)
+      #t
+      (if (syntax? stx)
+          (null? (syntax-e stx))
+          #f)))
+
+(define (stx-car stx)
+  (if (syntax? stx)
+      (car (syntax-e stx))
+      (car stx)))
+
+(define (stx-cdr stx)
+  (if (syntax? stx)
+      (cdr (syntax-e stx))
+      (cdr stx)))
+
+(define (identifier? stx)
+  (and (syntax? stx) (symbol? (syntax-e stx))))

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -195,16 +195,43 @@
   ; assumes form is `(<name> . <rest>)
   (define (check-define-syntaxes/values-form! name form)
     (define rib (stx-cdr form))
-    (let ([ids (syntax->list (stx-car rib))]
-          [rib (stx-cdr rib)])
-      (if (and (list? ids) (andmap identifier? ids))
-          (if (stx-null? rib)
-              (syntax-error name "expected an expression after identifiers" form)
-              (let ([rib (stx-cdr rib)])
-                (if (stx-null? rib)
-                    (void)
-                    (syntax-error name "too many expressions" form))))
-          (syntax-error name "not identifiers" form ids))))
+    (if (stx-null? rib)
+        (syntax-error name "bad syntax" form)
+        (let ([ids (syntax->list (stx-car rib))]
+              [rib (stx-cdr rib)])
+          (if (and (list? ids) (andmap identifier? ids))
+              (if (stx-null? rib)
+                  (syntax-error name "expected an expression after identifiers" form)
+                  (let ([rib (stx-cdr rib)])
+                    (if (stx-null? rib)
+                        (void)
+                        (syntax-error name "too many expressions" form))))
+              (syntax-error name "not identifiers" form ids)))))
+
+  ; checks if a `let-syntaxes` / `let-values` form is valid
+  ; assumes form is `(<name> . <rest>)
+  (define (check-let-syntaxes/values-form! name form)
+    (define rib (stx-cdr form))
+    (if (stx-null? rib)
+        (syntax-error name "bad syntax" form)
+        (let ([bindings (syntax->list (stx-car rib))]
+              [rib (stx-cdr rib)])
+          (if (null? rib)
+              (syntax-error name "missing body" form)
+              (if (or (list? rib) (and (syntax? rib) (list? (syntax->list rib))))
+                  (if (list? bindings)
+                      (let loop ([bindings bindings])
+                        (cond [(null? bindings) (void)]
+                              [else
+                              (let ([bind (syntax->list (car bindings))])
+                                (if (not (and (list? bind) (= (length bind) 2)))
+                                    (syntax-error name "not identifiers and expression" form bind)
+                                    (let ([ids (syntax->list (car bind))])
+                                      (if (and (list? ids) (andmap identifier? ids))
+                                          (loop (cdr bindings))
+                                          (syntax-error name "not identifiers" form ids)))))]))
+                      (syntax-error #f "expected a sequence of expressions after the bindings" form))
+                  (syntax-error name "not a sequence of bindings" form bindings))))))
 
   ; checks if a `lambda` form is valid
   ; assues form is `(lambda . <rest>)`
@@ -256,10 +283,10 @@
 
   ; checks for a duplicate identifier, raising an exception if one is encountered
   (define (check-duplicate-identifier! form name ids new-ids)
-    (define dup (duplicate-identifier ids new-ids))
-    (if dup
-        (syntax-error name "duplicate identifier" form dup)
-        (void)))
+    (let ([dup (duplicate-identifier ids new-ids)])
+      (if dup
+          (syntax-error name "duplicate identifier" form dup)
+          (void))))
 
   ; returns the identifiers of a `define-syntaxes` / `define-values` form
   (define (define-syntaxes/values-identifiers form)
@@ -302,6 +329,7 @@
   ; expression context
   ; Expr, List of Xform -> Expr
   (define (expand/expr expr xforms)
+    (set! $expander-pattern-vars (filter (lambda (e) (pattern-variable? (cdr e))) xforms))
     (let loop ([expr expr])
       (cond
         [(define-values-form? expr)
@@ -314,6 +342,59 @@
                  (car form)
                  (cadr form)
                  (loop (caddr form))))))]
+        [(let-syntaxes-form? expr)
+         (check-let-syntaxes/values-form! 'let-syntaxes expr)
+         (define form (syntax->list expr))
+         (let rec ([bindings (syntax->list (cadr form))] [let-ids null] [xforms xforms])
+           (cond
+             [(null? bindings)
+              (expand/expr  
+                (datum->syntax
+                  (cons (quote-syntax let-values)
+                    (cons (list)
+                      (cddr form))))
+                xforms)]
+             [else
+              (define binding (syntax->list (car bindings)))
+              (define binding-ids (syntax->datum (car binding)))
+              (check-duplicate-identifier! expr 'let-syntaxes let-ids binding-ids)
+              (define results
+                (let ([rhs (loop (cadr binding))])
+                  (eval/values (syntax->datum rhs) env $module-boot-expander?)))
+              (if (= (length binding-ids) (length results))
+                  (let bind-xforms ([ids binding-ids] [results results] [xforms xforms])
+                    (cond
+                      [(null? ids)
+                       (rec (cdr bindings) (append binding-ids let-ids) xforms)]
+                      [else
+                       (define id (car ids))
+                       (define xform (car results))
+                       (cond
+                         [(or (procedure? xform) (pattern-variable? xform))
+                          (define binding (cons id xform))
+                          (bind-xforms (cdr ids) (cdr results) (cons binding xforms))]
+                         [else
+                          (error 'let-syntaxes "expected a procedure? received" xform)])]))
+                  (error 'let-syntaxes "result arity mismatch"
+                         "expected" (length ids)
+                         "received" (length results)))]))]
+        [(or (let-values-form? expr) (letrec-values-form? expr))
+         (define name (if (let-values-form? expr) 'let-values 'letrec-values))
+         (check-let-syntaxes/values-form! name expr)
+         (define form (syntax->list expr))
+         (datum->syntax
+           (cons (car form)
+             (cons
+               (let rec ([bindings (syntax->list (cadr form))] [let-ids null])
+                 (cond
+                   [(null? bindings) null]
+                   [else
+                    (define binding (syntax->list (car bindings)))
+                    (define ids (syntax->datum (car binding)))
+                    (check-duplicate-identifier! expr name let-ids ids)
+                    (cons (list (car binding) (loop (cadr binding)))
+                          (rec (cdr bindings) (append ids let-ids)))]))
+               (map loop (cddr form)))))]
         [(lambda-form? expr)
          (check-lambda-form! expr)
          (define head (stx-car expr))
@@ -346,27 +427,21 @@
         [(stx-pair? expr)
          (define head (stx-car expr))
          (define maybe-xform (lookup-xform head xforms))
-         (cond
-           [maybe-xform
-            (loop (eval/xform maybe-xform expr (syntax-e head) $expander-boot-expander?))]
-           [else
-            (datum->syntax
-              (cons head
-                    (let rec ([tail (stx-cdr expr)])
-                      (cond [(null? tail) null]
-                            [(pair? tail) (cons (loop (car tail)) (rec (cdr tail)))]
-                            [else (loop tail)]))))])]
+         (if maybe-xform
+            (loop (eval/xform maybe-xform expr (syntax-e head) $module-boot-expander?))
+            (datum->syntax (map loop (syntax->list expr))))]
         [(identifier? expr)
-         expr]
+         (define maybe-xform (lookup-xform expr xforms))
+         (if maybe-xform
+             (loop (eval/xform maybe-xform expr (syntax-e head) $module-boot-expander?))
+             expr)]
         [(let ([datum (syntax-e expr)])
            (or (boolean? datum)
                (number? datum)
                (string? datum)))
          expr]
         [else
-          (writeln expr)
-        ;  (syntax-error #f "bad syntax" expr)
-         (expand expr xforms env)])))
+         (syntax-error #f "bad syntax" expr)])))
 
   ; module context
   ;  `define-values` => defers expansion until all expressions have been processed
@@ -387,18 +462,21 @@
                (check-define-syntaxes/values-form! 'define-syntaxes expr)
                (let ([ids (define-syntaxes/values-identifiers expr)])
                  (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
-                 (values ids (syntax->datum (define-syntaxes/values-expr expr))))))
-           (define results (eval/values rhs env $module-boot-expander?))
+                 (values ids (define-syntaxes/values-expr expr)))))
+           (define results
+             (let ([rhs* (expand/expr rhs xforms)])
+               (eval/values (syntax->datum rhs*) env $module-boot-expander?)))
            (if (= (length ids) (length results))
                (let bind-xforms ([ids ids] [results results] [xforms xforms] [xform-ids xform-ids])
                  (cond
                    [(null? ids)
-                    (loop (cdr exprs) (cdr xforms) value-ids xform-ids)]
+                    (loop (cdr exprs) xforms value-ids xform-ids)]
                    [else
-                    (define-values (id xform) (values (car ids) (car results)))
+                    (define id (car ids))
+                    (define xform (car results))
                     (cond
                       [(procedure? xform)
-                       (define binding (cons ids xform))
+                       (define binding (cons id xform))
                        (bind-xforms (cdr ids) (cdr results) (cons binding xforms) (cons id xform-ids))]
                       [else
                        (error 'define-syntaxes "expected a procedure? received" xform)])]))
@@ -414,7 +492,7 @@
           [(begin-form? (car exprs))
            (check-begin-form! (car exprs))
            (loop (append (cdr (syntax->list (car exprs))) (cdr exprs)) xforms value-ids xform-ids)]
-          [(stx-pair? (car exprs))
+          [(and (stx-pair? (car exprs)) (identifier? (stx-car (car exprs))))
            (define head (stx-car (car exprs)))
            (define maybe-xform (lookup-xform head xforms))
            (cond
@@ -422,11 +500,13 @@
               (define result (eval/xform maybe-xform (car exprs) (syntax-e head) $expander-boot-expander?))
               (loop (cons result (cdr exprs)) xforms value-ids xform-ids)]
              [else
+              (define expr* (expand/expr (car exprs) xforms))
               (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
-              (values (cons (expand/expr (car exprs) xforms) exprs*) xforms*)])]
+              (values (cons expr* exprs*) xforms*)])]
           [else
+           (define expr* (expand/expr (car exprs) xforms))
            (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
-           (values (cons (expand/expr (car exprs) xforms) exprs*) xforms*)])))
+           (values (cons expr* exprs*) xforms*)])))
     
     ; Any `define-values` form is deferred
     ; List of Expr, List of Xform -> List of Expr

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -7,10 +7,21 @@
 ;;;   Expander for syntax macros
 ;;;   
 
+;; Transforms "xforms" are procedures of one argument that
+;; take a syntax object as input and returns a syntax object.
+;; Transforms are introduced into scope via `define-syntaxes`
+;; in a top-level context and `let-syntaxes` in an
+;; expression-level context.
+;;
+;; This expander stores xforms as an association list mapping
+;;  <name> -> (<proc>, <xforms-in-scope>, <eval-env>)
+;;
+
 ;; Should the expander use the boot expander for evaluation?
 (define $expander-boot-expander? #f)
 (define $expander-pattern-vars null)
 
+;; Expand top-level form
 (define (expand expr xforms env)
   ;; looks up a transform returning #f if none is found
   (define (lookup-or-false key)
@@ -145,3 +156,127 @@
   (define expanded (expand-expr expr xforms))
   (set! $expander-pattern-vars null)
   expanded) 
+
+(define (expand/module exprs xforms env)
+  ; checks if an expression is a syntactic form:
+  ;  <expr> = (<name> . <rest>)
+  (define ((_-form? form-name) expr)
+    (and (stx-pair? expr)
+         (let ([head (stx-car expr)])
+           (and (identifier? head)
+                (eq? (syntax-e head) form-name)))))
+
+  (define define-values-form? (_-form? 'define-values))
+  (define define-syntaxes-form? (_-form? 'define-syntaxes))
+  (define let-syntaxes-form? (_-form? 'let-syntaxes))
+  (define begin-form? (_-form? 'begin))
+
+  ; returns an symbol if it is a duplicate, else false
+  (define (duplicate-identifier ids new-ids)
+    (let loop ([ids ids] [new-ids new-ids])
+      (cond [(null? new-ids) #f]
+            [else
+             (define dup (member (car new-ids) ids))
+             (if dup
+                 dup
+                 (loop (cons (car new-ids) ids) (cdr new-ids)))])))
+
+  ; checks is a `define-syntaxes` / `define-values` form is valid
+  ; assumes form is `(<name> . <rest>)
+  (define (check-define-syntaxes/values-form! name form)
+    (define rib (stx-cdr form))
+    (let ([ids (syntax->list (stx-car rib))]
+          [rib (stx-cdr rib)])
+      (if (and (list? ids) (andmap identifier? ids))
+          (if (stx-null? rib)
+              (syntax-error name "expected an expression after identifiers" form)
+              (let ([rib (stx-cdr rib)])
+                (if (stx-null? rib)
+                    (void)
+                    (syntax-error name "too many expressions" form))))
+          (syntax-error name "not identifiers" form ids))))
+
+  ; checks for a duplicate identifier, raising an exception if one is encountered
+  (define (check-duplicate-identifier! form name ids new-ids)
+    (define dup (duplicate-identifier ids new-ids))
+    (if dup
+        (syntax-error name "duplicate identifier" form dup)
+        (void)))
+
+  ; returns the identifiers of a `define-syntaxes` / `define-values` form
+  ; assumes the form is valid
+  (define (define-syntaxes/values-identifiers form)
+    (map syntax-e (syntax->list (stx-car (stx-cdr form)))))
+
+  (define (define-syntaxes/values-expr form)
+    (stx-car (stx-cdr (stx-cdr form))))
+
+  ; expression context
+  ; Expr, List of Xform -> Expr
+  (define (expand/expr expr xforms)
+    (expand expr xforms env))
+
+  ; top-level context
+  ; Expr, List of Xform -> Expr
+  (define (expand/top expr xforms)
+    (cond
+      [else (expand/expr expr xforms)]))
+    ; (cond
+    ;   [(define-values-form? expr)
+    ;    ; define-values form
+    ;    (values expr xforms)]
+    ;   [(define-syntaxes-form? expr)
+    ;    ; define-syntaxes form
+    ;    (values expr xforms)]
+    ;   [else
+    ;    ; expression form
+    ;    (values (expand/expr expr xforms) xforms)]))
+
+  ; module context
+  ; `define-values` => defers expansion until all expressions have been processed
+  ; `define-syntaxes` => expands and evaluates RHS and updates `xforms`
+  ; `begin` => splices sequence of expressions
+  ; <expr> => invokes top-level expander
+  ; List of Expr, List of Xform, List of Symbols -> List of Expr, List of Xforms
+  (define (expand/module exprs xforms)
+    (let loop ([exprs exprs] [exprs* null] [xforms xforms] [new-xforms null] [defines null])
+      (cond
+        [(null? exprs)
+         (values exprs* xforms)]
+        [(define-syntaxes-form? (car exprs))
+         (define-values (ids rhs)
+           (let ([expr (car exprs)])
+             (check-define-syntaxes/values-form! 'define-syntaxes expr)
+             (define ids (define-syntaxes/values-identifiers expr))
+             (check-duplicate-identifier! expr 'define-syntaxes new-xforms ids)
+             (values ids (syntax->datum (define-syntaxes/values-expr expr)))))
+          (define old-expander? (boot-expander?))
+          (call-with-values
+            (lambda ()
+              (boot-expander? $module-boot-expander?)
+              (eval rhs env))
+            (lambda results
+              (boot-expander? old-expander?)
+              (if (= (length ids) (length results))
+                  (let loop2 ([ids ids] [results results] [xforms xforms] [new-xforms new-xforms])
+                    (cond
+                      [(null? ids) (loop (cdr exprs) exprs* xforms new-xforms defines)]
+                      [else
+                       (define-values (id xform) (values (car ids) (car results)))
+                       (cond
+                         [(procedure? xform)
+                          (define binding (cons ids xform))
+                          (loop2 (cdr ids) (cdr results) (cons binding xforms) (cons id new-xforms))]
+                         [else
+                          (error 'define-syntaxes "expected a procedure? received" xform)])]))
+                  (error 'define-syntaxes "result arity mismatch" "expected"
+                          (length ids) "received" (length results)))))]
+        [(define-values-form? (car exprs))
+         (check-define-syntaxes/values-form! 'define-values (car exprs))
+         (loop (cdr exprs) (cons (car exprs) exprs*) xforms new-xforms (cons (car exprs) defines))]
+        [else
+         (loop (cdr exprs) (cons (expand/top (car exprs) xforms) exprs*) new-xforms xforms defines)])))
+
+
+  ; invoke the module-level expander
+  (expand/module exprs xforms))

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -341,62 +341,71 @@
 
     ; List of Expr, List of Xform -> List of Expr, List of Xform
     (define (expand/non-define-values exprs xforms)
-      (let loop ([exprs exprs] [xforms xforms] [define-ids null] [xform-ids null])
-        (cond
-          [(null? exprs) (values null xforms)]
-          [else
-           (define-values (expr xforms-in-scope) (expand/top-level (car exprs) xforms))
-           (cond
-             [(define-syntaxes-form? expr)
-              (check-define-syntaxes/values-form! 'define-syntaxes expr)
-              (define-values (ids rhs)
-                (let ([ids (define-syntaxes/values-identifiers expr)])
-                  (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
-                  (values ids (define-syntaxes/values-expr expr))))
-              (define results
-                (let ([rhs* (expand/expr rhs xforms)])
-                  (eval/values (syntax->datum rhs*) env $module-boot-expander?)))
-              (if (= (length ids) (length results))
-                  (let bind-xforms ([ids ids] [results results] [xforms xforms] [xform-ids xform-ids])
-                    (cond
-                      [(null? ids)
-                       (loop (cdr exprs) xforms define-ids xform-ids)]
-                      [else
-                       (define id (car ids))
-                       (define xform (car results))
-                       (cond
-                         [(procedure? xform)
-                          (define binding (cons id (list xform xforms)))
-                          (define xforms*
-                            (let update ([to-update xforms])
-                              (cond [(null? to-update) null]
-                                    [(member (caar to-update) xform-ids)
-                                     (cons
-                                       (cons (caar to-update) (list (cadar to-update) xforms))
-                                       (update (cdr to-update)))]
-                                    [else
-                                     (cons (car to-update) (update (cdr to-update)))])))
-                          (bind-xforms (cdr ids)
-                                       (cdr results)
-                                       (cons binding xforms*)
-                                       (cons id xform-ids))]
-                         [else
-                          (error 'define-syntaxes "expected a procedure? received" xform)])]))
-                  (error 'define-syntaxes "result arity mismatch" "expected"
-                         (length ids) "received" (length results)))]
-             [(define-values-form? expr)
-              (check-define-syntaxes/values-form! 'define-values expr)
-              (define ids (define-syntaxes/values-identifiers expr))
-              (check-duplicate-identifier! expr 'define-values define-ids ids)
-              (define-values (exprs* xforms*) (loop (cdr exprs) xforms (append ids define-ids) xform-ids))
-              (values (cons expr exprs*) xforms*)]
-             [(begin-form? expr)
-              (check-begin-form! expr)
-              (loop (append (cdr (syntax->list expr)) (cdr exprs)) xforms define-ids xform-ids)]
-             [else
-              (define expr* (expand/expr expr xforms-in-scope))
-              (define-values (exprs* xforms*) (loop (cdr exprs) xforms define-ids xform-ids))
-              (values (cons expr* exprs*) xforms*)])])))
+      ; mutatable state
+      (define xforms xforms)
+      (define define-ids null)
+      (define xform-ids null)
+      ; for each expression
+      (define exprs*
+        (let loop ([exprs exprs])
+          (cond
+            [(null? exprs) null]
+            [else
+             (let with-scope ([exprs exprs] [in-scope xforms])
+               (define-values (expr in-scope) (expand/top-level (car exprs) in-scope))
+               (cond
+                 [(define-syntaxes-form? expr)
+                  (check-define-syntaxes/values-form! 'define-syntaxes expr)
+                  (define-values (ids rhs)
+                    (let ([ids (define-syntaxes/values-identifiers expr)])
+                      (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
+                      (values ids (define-syntaxes/values-expr expr))))
+                  (define results
+                    (let ([rhs* (expand/expr rhs in-scope)])
+                      (eval/values (syntax->datum rhs*) env $module-boot-expander?)))
+                  (if (= (length ids) (length results))
+                      (let rec ([ids ids] [results results])
+                        (cond
+                          [(null? ids) (loop (cdr exprs))]
+                          [else
+                           (define id (car ids))
+                           (define xform (car results))
+                           (cond
+                             [(procedure? xform)
+                              (define binding (cons id (list xform null)))
+                              (set! xform-ids (cons id xform-ids))
+                              (set! xforms
+                                (let ([xforms-in-scope (cons binding xforms)])
+                                  (let loop ([xforms xforms-in-scope])
+                                    (cond
+                                      [(null? xforms) null]
+                                      [else
+                                       (cons
+                                         (if (member (caar xforms) xform-ids)
+                                             (cons (caar xforms) (list (cadar xforms) xforms-in-scope))
+                                             (car xforms))
+                                         (loop (cdr xforms)))]))))
+                              (rec (cdr ids) (cdr results))]
+                             [else
+                              (error 'define-syntaxes
+                                     "expected a procedure? received"
+                                     xform)])]))
+                      (error 'define-syntaxes "result arity mismatch" "expected"
+                             (length ids) "received" (length results)))]
+                 [(define-values-form? expr)
+                  (check-define-syntaxes/values-form! 'define-values expr)
+                  (define ids (define-syntaxes/values-identifiers expr))
+                  (check-duplicate-identifier! expr 'define-values define-ids ids)
+                  (set! define-ids (append ids define-ids))
+                  (cons expr (loop (cdr exprs)))]
+                 [(begin-form? expr)
+                  (check-begin-form! expr)
+                  (append (with-scope (cdr (syntax->list expr)) in-scope)
+                          (loop (cdr exprs)))]
+                 [else
+                  (cons (expand/expr expr in-scope) (loop (cdr exprs)))]))])))
+      ; done
+      (values exprs* xforms))
     
     ; Any `define-values` form is deferred
     ; List of Expr, List of Xform -> List of Expr

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -21,142 +21,7 @@
 (define $expander-boot-expander? #f)
 (define $expander-pattern-vars null)
 
-;; Expand top-level form
-(define (expand expr xforms env)
-  ;; looks up a transform returning #f if none is found
-  (define (lookup-or-false key)
-    (let loop ([xforms xforms])
-      (cond [(null? xforms) #f]
-            [(eq? (caar xforms) key) (cdar xforms)]
-            [else (loop (cdr xforms))])))
-
-  ;; expression-level expander
-  (define (expand-expr expr xforms)
-    (define expr* (syntax-e expr))
-    (set! $expander-pattern-vars
-          (filter (lambda (e) (pattern-variable? (cdr e))) xforms))
-    (cond
-      [(null? expr*)
-        expr]
-      [(pair? expr*)
-       (define first (syntax-e (car expr*)))
-       (cond
-         [(symbol? first)
-          (define maybe-xform (lookup-or-false first))
-          (define maybe-args (cdr expr*))
-          (datum->syntax
-            (cond
-              [(and maybe-xform (procedure? maybe-xform))
-               (define old-expander? (boot-expander?))
-               (define expanded
-                 (call-with-values
-                   (lambda ()
-                    ;  (display "< ") (writeln expr)
-                     (boot-expander? $expander-boot-expander?)
-                     (maybe-xform expr))
-                   (lambda results
-                     (boot-expander? old-expander?)
-                     (if (and (= (length results) 1) (syntax? (car results)))
-                         (car results)
-                         (error 'expander
-                                "transformer produced something other than syntax"
-                                (car results))))))
-              ;  (display "> ") (writeln expanded)
-               (define expanded* (expand-expr expanded xforms))
-              ;  (display "> ") (writeln expanded*)
-               expanded*]
-              [(eq? first 'let-syntaxes)
-               (define (panic!) (syntax-error 'let-syntaxes "bad syntax" expr))
-               (define rib maybe-args)
-               (define maybe-bindings (syntax-e (car rib)))
-               (cond
-                 [(list? maybe-bindings)
-                  (let loop ([bindings maybe-bindings])
-                    (cond
-                      [(null? bindings)
-                       (define exprs (cdr rib))
-                       (if (list? exprs)
-                           (cons (quote-syntax let-values)
-                             (cons (quote-syntax ())
-                               (map (lambda (e) (expand-expr e xforms)) exprs)))
-                           (syntax-error 'let-syntaxes "bad syntax" expr))]
-                      [else
-                       (define maybe-binding (syntax-e (car bindings)))
-                       (cond
-                         [(and (list? maybe-binding) (= (length maybe-binding) 2))
-                          (define ids (syntax-e (car maybe-binding)))
-                          (define val (cadr maybe-binding))
-                          (cond
-                            [(list? ids)
-                             (define xform-names
-                               (let loop ([names ids] [acc '()])
-                               (if (null? names)
-                                   (reverse acc)
-                                   (loop (cdr names)
-                                         (cons (syntax-e (car names)) acc)))))
-                             (define expr (syntax->datum val))
-                             (define old-expander? (boot-expander?))
-                             (call-with-values
-                               (lambda ()
-                                 (boot-expander? $expander-boot-expander?)
-                                 (eval expr env))
-                               (lambda results
-                                 (boot-expander? old-expander?)
-                                 (if (not (= (length xform-names) (length results)))
-                                     (error 'let-syntaxes "result arity mismatch" "expected"
-                                            (length xform-names) "received" (length results))
-                                     (let loop ([xform-names xform-names] [results results])
-                                       (cond
-                                         [(null? xform-names)
-                                          (void)]
-                                         [else
-                                          (let ([xform-name (car xform-names)]
-                                                [xform (car results)])
-                                            (cond
-                                              [(or (procedure? xform) (pattern-variable? xform))
-                                               (define binding (cons xform-name xform))
-                                               (set! xforms (cons binding xforms))
-                                               (loop (cdr xform-names) (cdr results))]
-                                              [else
-                                               (error 'let-syntaxes
-                                                      "expected a procedure, received"
-                                                      xform)]))])))))
-                             (loop (cdr bindings))]
-                            [else
-                             (panic!)])]
-                         [else (panic!)])]))]
-                 [else (panic!)])]
-              [(or (eq? first 'quote-syntax)
-                   (eq? first 'quote))
-               expr*]
-              [else
-               (cons
-                 (car expr*)
-                 (let loop ([args maybe-args])
-                   (cond
-                     [(null? args) '()]
-                     [(pair? args) (cons (expand-expr (car args) xforms) (loop (cdr args)))]
-                     [else (expand-expr args xforms)])))]))]
-         [else
-          (datum->syntax
-            (let loop ([args expr*])
-              (cond
-                [(null? args) '()]
-                [(pair? args) (cons (expand-expr (car args) xforms) (loop (cdr args)))]
-                [else (expand-expr args xforms)])))])]
-      [(symbol? expr*)
-       (define maybe-xform (lookup-or-false expr*))
-       (datum->syntax
-         (if maybe-xform
-             (expand-expr (maybe-xform expr) xforms)
-             expr))]
-      [else
-       expr]))
-
-  (define expanded (expand-expr expr xforms))
-  (set! $expander-pattern-vars null)
-  expanded) 
-
+;; Expands a module (List of Expr, List of Xform, Env)
 (define (expand/module exprs xforms env)
   ; checks if an expression is a syntactic form:
   ;  <expr> = (<name> . <rest>)
@@ -531,3 +396,9 @@
 
   ; invoke the module-level expander
   (expand/module exprs xforms))
+
+;; Expands a single expression
+(define (expand expr xforms env)
+  (define-values (exprs* xforms*) (expand/module (list expr) xforms env))
+  (cond [(null? exprs*) (values (quote-syntax (void)) xforms*)]
+        [else (values (car exprs*) xforms*)]))

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -168,8 +168,18 @@
 
   (define define-values-form? (_-form? 'define-values))
   (define define-syntaxes-form? (_-form? 'define-syntaxes))
+  (define let-values-form? (_-form? 'let-values))
+  (define letrec-values-form? (_-form? 'letrec-values))
   (define let-syntaxes-form? (_-form? 'let-syntaxes))
+  (define quote-form? (_-form? 'quote))
+  (define quote-syntax-form? (_-form? 'quote-syntax))
+  (define lambda-form? (_-form? 'lambda))
   (define begin-form? (_-form? 'begin))
+  (define if-form? (_-form? 'if))
+
+  (define (lookup-xform maybe-id xforms)
+    (and (identifier? maybe-id)
+         (assoc (syntax-e maybe-id) xforms)))
 
   ; returns an symbol if it is a duplicate, else false
   (define (duplicate-identifier ids new-ids)
@@ -181,7 +191,7 @@
                  dup
                  (loop (cons (car new-ids) ids) (cdr new-ids)))])))
 
-  ; checks is a `define-syntaxes` / `define-values` form is valid
+  ; checks if a `define-syntaxes` / `define-values` form is valid
   ; assumes form is `(<name> . <rest>)
   (define (check-define-syntaxes/values-form! name form)
     (define rib (stx-cdr form))
@@ -196,6 +206,54 @@
                     (syntax-error name "too many expressions" form))))
           (syntax-error name "not identifiers" form ids))))
 
+  ; checks if a `lambda` form is valid
+  ; assues form is `(lambda . <rest>)`
+  (define (check-lambda-form! form)
+    (define rib (stx-cdr form))
+    (if (stx-null? rib)
+        (syntax-error #f "missing formals" form)
+        (let ([formals (stx-car rib)]
+              [rib (stx-cdr rib)])
+          (if (null? rib)
+              (syntax-error #f "missing expression after formals" form)
+              (let ([rib (stx-cdr rib)])
+                (if (or (list? rib) (and (syntax? rib) (list? (syntax->list rib))))
+                    (void)
+                    (syntax-error #f "expected a sequence of expressions after formals" form)))))))
+
+  ; checks if a `begin` form is valid
+  ; assues form is `(<name> . <rest>)`
+  (define (check-begin-form! form)
+    (if (syntax->list form)
+        (void)
+        (syntax-error 'begin "bad syntax" form)))
+
+  ; checks if a unary form is valid, i.e. `(<name> <expr>)`.
+  (define (check-1ary-form! name form)
+    (define rib (stx-cdr form))
+    (if (stx-null? rib)
+        (syntax-error name "expected an expression" form)
+        (let ([rib (stx-cdr rib)])
+          (if (stx-null? rib)
+              (void)
+              (syntax-error name "too many expressions" form)))))
+
+  ; checks if an `if` form is valid, i.e. `(if <cond> <if-true> <if-false>)`.
+  (define (check-if-form! form)
+    (define rib (stx-cdr form))
+    (if (stx-null? rib)
+        (syntax-error 'if "bad syntax" form)
+        (let ([rib (stx-cdr rib)])
+          (if (stx-null? rib)
+              (syntax-error 'if "bad syntax" form)
+              (let ([rib (stx-cdr rib)])
+                (if (stx-null? rib)
+                    (syntax-error 'if "missing an \"else\" statement" form)
+                    (let ([rib (stx-cdr rib)])
+                      (if (stx-null? rib)
+                          (void)
+                          (syntax-error name "too many expressions" form)))))))))
+
   ; checks for a duplicate identifier, raising an exception if one is encountered
   (define (check-duplicate-identifier! form name ids new-ids)
     (define dup (duplicate-identifier ids new-ids))
@@ -204,79 +262,192 @@
         (void)))
 
   ; returns the identifiers of a `define-syntaxes` / `define-values` form
-  ; assumes the form is valid
   (define (define-syntaxes/values-identifiers form)
     (map syntax-e (syntax->list (stx-car (stx-cdr form)))))
 
+  ; returns the expr of a `define-syntaxes` / `define-values` form
   (define (define-syntaxes/values-expr form)
     (stx-car (stx-cdr (stx-cdr form))))
+
+  ; evaluates an expression in a given environment returning potentially
+  ; multiple values the `boot-expander?` parameter is set with `expander?`
+  (define (eval/values expr env expander?)
+    (define old-expander? (boot-expander?))
+    (call-with-values
+      (lambda ()
+        (boot-expander? expander?)
+        (eval expr env))
+      (lambda results
+        (boot-expander? old-expander?)
+        results)))
+  
+  ; evaluates an expression in a given environment returning potentially
+  ; multiple values the `boot-expander?` parameter is set with `expander?`
+  (define (eval/xform xform expr name expander?)
+    (define old-expander? (boot-expander?))
+    (call-with-values
+      (lambda ()
+        (boot-expander? expander?)
+        (xform expr))
+      (lambda results
+        (boot-expander? old-expander?)
+        (cond
+          [(not (= (length results) 1)) 
+           (error #f "result arity mismatch" "expected 1" "received" 2)]
+          [(syntax? (car results))
+           (car results)]
+          [else
+           (error name "transformer produced something other than syntax" (car results))]))))
 
   ; expression context
   ; Expr, List of Xform -> Expr
   (define (expand/expr expr xforms)
-    (expand expr xforms env))
-
-  ; top-level context
-  ; Expr, List of Xform -> Expr
-  (define (expand/top expr xforms)
-    (cond
-      [else (expand/expr expr xforms)]))
-    ; (cond
-    ;   [(define-values-form? expr)
-    ;    ; define-values form
-    ;    (values expr xforms)]
-    ;   [(define-syntaxes-form? expr)
-    ;    ; define-syntaxes form
-    ;    (values expr xforms)]
-    ;   [else
-    ;    ; expression form
-    ;    (values (expand/expr expr xforms) xforms)]))
+    (let loop ([expr expr])
+      (cond
+        [(define-values-form? expr)
+         (check-define-syntaxes/values-form! 'define-values expr)
+         (let ([ids (define-syntaxes/values-identifiers expr)])
+           (check-duplicate-identifier! expr 'define-values null ids)
+           (let ([form (syntax->list expr)])
+             (datum->syntax
+               (list
+                 (car form)
+                 (cadr form)
+                 (loop (caddr form))))))]
+        [(lambda-form? expr)
+         (check-lambda-form! expr)
+         (define head (stx-car expr))
+         (define formals (stx-car (stx-cdr expr)))
+         (define body (stx-cdr (stx-cdr expr)))
+         (datum->syntax
+           (cons head
+             (cons formals
+               (map loop body))))]
+        [(if-form? expr)
+         (check-if-form! expr)
+         (define form (syntax->list expr))
+         (datum->syntax
+           (list
+            (car form)
+            (loop (cadr form))
+            (loop (caddr form))
+            (loop (cadddr form))))]
+        [(begin-form? expr)
+         (check-begin-form! expr)
+         (datum->syntax
+           (cons (stx-car expr)
+                 (map loop (cdr (syntax->list expr)))))]
+        [(quote-form? expr)
+         (check-1ary-form! 'quote expr)
+         expr]
+        [(quote-syntax-form? expr)
+         (check-1ary-form! 'quote-syntax expr)
+         expr]
+        [(stx-pair? expr)
+         (define head (stx-car expr))
+         (define maybe-xform (lookup-xform head xforms))
+         (cond
+           [maybe-xform
+            (loop (eval/xform maybe-xform expr (syntax-e head) $expander-boot-expander?))]
+           [else
+            (datum->syntax
+              (cons head
+                    (let rec ([tail (stx-cdr expr)])
+                      (cond [(null? tail) null]
+                            [(pair? tail) (cons (loop (car tail)) (rec (cdr tail)))]
+                            [else (loop tail)]))))])]
+        [(identifier? expr)
+         expr]
+        [(let ([datum (syntax-e expr)])
+           (or (boolean? datum)
+               (number? datum)
+               (string? datum)))
+         expr]
+        [else
+          (writeln expr)
+        ;  (syntax-error #f "bad syntax" expr)
+         (expand expr xforms env)])))
 
   ; module context
-  ; `define-values` => defers expansion until all expressions have been processed
-  ; `define-syntaxes` => expands and evaluates RHS and updates `xforms`
-  ; `begin` => splices sequence of expressions
-  ; <expr> => invokes top-level expander
-  ; List of Expr, List of Xform, List of Symbols -> List of Expr, List of Xforms
+  ;  `define-values` => defers expansion until all expressions have been processed
+  ;  `define-syntaxes` => expands and evaluates RHS and updates `xforms`
+  ;  `begin` => splices sequence of expressions
+  ;  <expr> => invokes top-level expander
+  ; List of Expr, List of Xform -> List of Expr, List of Xform
   (define (expand/module exprs xforms)
-    (let loop ([exprs exprs] [exprs* null] [xforms xforms] [new-xforms null] [defines null])
-      (cond
-        [(null? exprs)
-         (values exprs* xforms)]
-        [(define-syntaxes-form? (car exprs))
-         (define-values (ids rhs)
-           (let ([expr (car exprs)])
-             (check-define-syntaxes/values-form! 'define-syntaxes expr)
-             (define ids (define-syntaxes/values-identifiers expr))
-             (check-duplicate-identifier! expr 'define-syntaxes new-xforms ids)
-             (values ids (syntax->datum (define-syntaxes/values-expr expr)))))
-          (define old-expander? (boot-expander?))
-          (call-with-values
-            (lambda ()
-              (boot-expander? $module-boot-expander?)
-              (eval rhs env))
-            (lambda results
-              (boot-expander? old-expander?)
-              (if (= (length ids) (length results))
-                  (let loop2 ([ids ids] [results results] [xforms xforms] [new-xforms new-xforms])
+    ; List of Expr, List of Xform -> List of Expr, List of Xform
+    (define (expand/non-define-values exprs xforms)
+      (let loop ([exprs exprs] [xforms xforms] [value-ids null] [xform-ids null])
+        (cond
+          [(null? exprs)
+           (values null xforms)]
+          [(define-syntaxes-form? (car exprs))
+           (define-values (ids rhs)
+             (let ([expr (car exprs)])
+               (check-define-syntaxes/values-form! 'define-syntaxes expr)
+               (let ([ids (define-syntaxes/values-identifiers expr)])
+                 (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
+                 (values ids (syntax->datum (define-syntaxes/values-expr expr))))))
+           (define results (eval/values rhs env $module-boot-expander?))
+           (if (= (length ids) (length results))
+               (let bind-xforms ([ids ids] [results results] [xforms xforms] [xform-ids xform-ids])
+                 (cond
+                   [(null? ids)
+                    (loop (cdr exprs) (cdr xforms) value-ids xform-ids)]
+                   [else
+                    (define-values (id xform) (values (car ids) (car results)))
                     (cond
-                      [(null? ids) (loop (cdr exprs) exprs* xforms new-xforms defines)]
+                      [(procedure? xform)
+                       (define binding (cons ids xform))
+                       (bind-xforms (cdr ids) (cdr results) (cons binding xforms) (cons id xform-ids))]
                       [else
-                       (define-values (id xform) (values (car ids) (car results)))
-                       (cond
-                         [(procedure? xform)
-                          (define binding (cons ids xform))
-                          (loop2 (cdr ids) (cdr results) (cons binding xforms) (cons id new-xforms))]
-                         [else
-                          (error 'define-syntaxes "expected a procedure? received" xform)])]))
-                  (error 'define-syntaxes "result arity mismatch" "expected"
-                          (length ids) "received" (length results)))))]
-        [(define-values-form? (car exprs))
-         (check-define-syntaxes/values-form! 'define-values (car exprs))
-         (loop (cdr exprs) (cons (car exprs) exprs*) xforms new-xforms (cons (car exprs) defines))]
-        [else
-         (loop (cdr exprs) (cons (expand/top (car exprs) xforms) exprs*) new-xforms xforms defines)])))
+                       (error 'define-syntaxes "expected a procedure? received" xform)])]))
+               (error 'define-syntaxes "result arity mismatch" "expected"
+                      (length ids) "received" (length results)))]
+          [(define-values-form? (car exprs))
+           (define ids
+             (let ([expr (car exprs)])
+               (check-define-syntaxes/values-form! 'define-values expr)
+               (define-syntaxes/values-identifiers expr)))
+           (define-values (exprs* xforms*) (loop (cdr exprs) xforms (append ids value-ids) xform-ids))
+           (values (cons (car exprs) exprs*) xforms*)]
+          [(begin-form? (car exprs))
+           (check-begin-form! (car exprs))
+           (loop (append (cdr (syntax->list (car exprs))) (cdr exprs)) xforms value-ids xform-ids)]
+          [(stx-pair? (car exprs))
+           (define head (stx-car (car exprs)))
+           (define maybe-xform (lookup-xform head xforms))
+           (cond
+             [maybe-xform
+              (define result (eval/xform maybe-xform (car exprs) (syntax-e head) $expander-boot-expander?))
+              (loop (cons result (cdr exprs)) xforms value-ids xform-ids)]
+             [else
+              (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
+              (values (cons (expand/expr (car exprs) xforms) exprs*) xforms*)])]
+          [else
+           (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
+           (values (cons (expand/expr (car exprs) xforms) exprs*) xforms*)])))
+    
+    ; Any `define-values` form is deferred
+    ; List of Expr, List of Xform -> List of Expr
+    (define (expand/define-values exprs xforms)
+      (let loop ([exprs exprs] [exprs* null])
+        (cond
+          [(null? exprs) (reverse exprs*)]
+          [(define-values-form? (car exprs))
+           (define form (syntax->list (car exprs)))
+           (loop (cdr exprs)
+                 (cons
+                   (datum->syntax
+                     (list
+                       (car form)
+                       (cadr form)
+                       (expand/expr (caddr form) xforms)))
+                   exprs*))]
+          [else (loop (cdr exprs) (cons (car exprs) exprs*))])))
 
+    (define-values (exprs* xforms*) (expand/non-define-values exprs xforms))
+    (values (expand/define-values exprs* xforms*) xforms*))
 
   ; invoke the module-level expander
   (expand/module exprs xforms))

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -21,6 +21,16 @@
 (define $expander-boot-expander? #f)
 (define $expander-pattern-vars null)
 
+(define (lookup-xform maybe-id xforms)
+  (and (identifier? maybe-id)
+       (assoc (syntax-e maybe-id) xforms)))
+
+(define (merge-xforms new-xforms xforms)
+  (let loop ([new-xforms new-xforms] [xforms xforms])
+    (cond [(null? new-xforms) xforms]
+          [(assoc (caar new-xforms) xforms) (loop (cdr new-xforms) xforms)]
+          [else (loop (cdr new-xforms) (cons (car new-xforms) xforms))])))
+
 ;; Expands a module (List of Expr, List of Xform, Env)
 (define (expand/module exprs xforms env)
   ; checks if an expression is a syntactic form:
@@ -42,19 +52,13 @@
   (define begin-form? (_-form? 'begin))
   (define if-form? (_-form? 'if))
 
-  (define (lookup-xform maybe-id xforms)
-    (and (identifier? maybe-id)
-         (assoc (syntax-e maybe-id) xforms)))
-
   ; returns an symbol if it is a duplicate, else false
   (define (duplicate-identifier ids new-ids)
     (let loop ([ids ids] [new-ids new-ids])
       (cond [(null? new-ids) #f]
             [else
              (define dup (member (car new-ids) ids))
-             (if dup
-                 dup
-                 (loop (cons (car new-ids) ids) (cdr new-ids)))])))
+             (or dup (loop (cons (car new-ids) ids) (cdr new-ids)))])))
 
   ; checks if a `define-syntaxes` / `define-values` form is valid
   ; assumes form is `(<name> . <rest>)
@@ -176,11 +180,12 @@
   ; evaluates an expression in a given environment returning potentially
   ; multiple values the `boot-expander?` parameter is set with `expander?`
   (define (eval/xform xform expr name expander?)
+    (define fn (car xform))
     (define old-expander? (boot-expander?))
     (call-with-values
       (lambda ()
         (boot-expander? expander?)
-        (xform expr))
+        (fn expr))
       (lambda results
         (boot-expander? old-expander?)
         (cond
@@ -194,7 +199,7 @@
   ; expression context
   ; Expr, List of Xform -> Expr
   (define (expand/expr expr xforms)
-    (set! $expander-pattern-vars (filter (lambda (e) (pattern-variable? (cdr e))) xforms))
+    (set! $expander-pattern-vars (filter (lambda (e) (pattern-variable? (cadr e))) xforms))
     (let loop ([expr expr])
       (cond
         [(define-values-form? expr)
@@ -236,8 +241,8 @@
                        (define xform (car results))
                        (cond
                          [(or (procedure? xform) (pattern-variable? xform))
-                          (define binding (cons id xform))
-                          (bind-xforms (cdr ids) (cdr results) (cons binding xforms))]
+                          (define xform-entry (cons id (list xform xforms)))
+                          (bind-xforms (cdr ids) (cdr results) (cons xform-entry xforms))]
                          [else
                           (error 'let-syntaxes "expected a procedure? received" xform)])]))
                   (error 'let-syntaxes "result arity mismatch"
@@ -293,7 +298,8 @@
          (define head (stx-car expr))
          (define maybe-xform (lookup-xform head xforms))
          (if maybe-xform
-            (loop (eval/xform maybe-xform expr (syntax-e head) $module-boot-expander?))
+            (expand/expr (eval/xform maybe-xform expr (syntax-e head) $module-boot-expander?)
+                         (merge-xforms (cadr maybe-xform) xforms))
             (datum->syntax (map loop (syntax->list expr))))]
         [(identifier? expr)
          (define maybe-xform (lookup-xform expr xforms))
@@ -309,69 +315,88 @@
          (syntax-error #f "bad syntax" expr)])))
 
   ; module context
-  ;  `define-values` => defers expansion until all expressions have been processed
+  ;  `define-values` => defers expansion until all definitions have been processed
   ;  `define-syntaxes` => expands and evaluates RHS and updates `xforms`
   ;  `begin` => splices sequence of expressions
   ;  <expr> => invokes top-level expander
   ; List of Expr, List of Xform -> List of Expr, List of Xform
   (define (expand/module exprs xforms)
+    ; Expr, List of Xform -> Expr, List of Xform
+    (define (expand/top-level expr xforms)
+      (cond
+        [(define-syntaxes-form? expr) (values expr xforms)]
+        [(define-values-form? expr) (values expr xforms)]
+        [(begin-form? expr) (values expr xforms)]
+        [(and (stx-pair? expr) (identifier? (stx-car expr)))
+         (define head (stx-car expr))
+         (define maybe-xform (lookup-xform head xforms))
+         (cond
+           [maybe-xform
+            (expand/top-level
+              (eval/xform maybe-xform expr (syntax-e head) $expander-boot-expander?)
+              (merge-xforms (cadr maybe-xform) xforms))]
+           [else
+            (values expr xforms)])]
+        [else (values expr xforms)]))
+
     ; List of Expr, List of Xform -> List of Expr, List of Xform
     (define (expand/non-define-values exprs xforms)
-      (let loop ([exprs exprs] [xforms xforms] [value-ids null] [xform-ids null])
+      (let loop ([exprs exprs] [xforms xforms] [define-ids null] [xform-ids null])
         (cond
-          [(null? exprs)
-           (values null xforms)]
-          [(define-syntaxes-form? (car exprs))
-           (define-values (ids rhs)
-             (let ([expr (car exprs)])
-               (check-define-syntaxes/values-form! 'define-syntaxes expr)
-               (let ([ids (define-syntaxes/values-identifiers expr)])
-                 (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
-                 (values ids (define-syntaxes/values-expr expr)))))
-           (define results
-             (let ([rhs* (expand/expr rhs xforms)])
-               (eval/values (syntax->datum rhs*) env $module-boot-expander?)))
-           (if (= (length ids) (length results))
-               (let bind-xforms ([ids ids] [results results] [xforms xforms] [xform-ids xform-ids])
-                 (cond
-                   [(null? ids)
-                    (loop (cdr exprs) xforms value-ids xform-ids)]
-                   [else
-                    (define id (car ids))
-                    (define xform (car results))
-                    (cond
-                      [(procedure? xform)
-                       (define binding (cons id xform))
-                       (bind-xforms (cdr ids) (cdr results) (cons binding xforms) (cons id xform-ids))]
-                      [else
-                       (error 'define-syntaxes "expected a procedure? received" xform)])]))
-               (error 'define-syntaxes "result arity mismatch" "expected"
-                      (length ids) "received" (length results)))]
-          [(define-values-form? (car exprs))
-           (define ids
-             (let ([expr (car exprs)])
-               (check-define-syntaxes/values-form! 'define-values expr)
-               (define-syntaxes/values-identifiers expr)))
-           (define-values (exprs* xforms*) (loop (cdr exprs) xforms (append ids value-ids) xform-ids))
-           (values (cons (car exprs) exprs*) xforms*)]
-          [(begin-form? (car exprs))
-           (check-begin-form! (car exprs))
-           (loop (append (cdr (syntax->list (car exprs))) (cdr exprs)) xforms value-ids xform-ids)]
-          [(and (stx-pair? (car exprs)) (identifier? (stx-car (car exprs))))
-           (define head (stx-car (car exprs)))
-           (define maybe-xform (lookup-xform head xforms))
-           (cond
-             [maybe-xform
-              (define result (eval/xform maybe-xform (car exprs) (syntax-e head) $expander-boot-expander?))
-              (loop (cons result (cdr exprs)) xforms value-ids xform-ids)]
-             [else
-              (define expr* (expand/expr (car exprs) xforms))
-              (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
-              (values (cons expr* exprs*) xforms*)])]
+          [(null? exprs) (values null xforms)]
           [else
-           (define expr* (expand/expr (car exprs) xforms))
-           (define-values (exprs* xforms*) (loop (cdr exprs) xforms value-ids xform-ids))
-           (values (cons expr* exprs*) xforms*)])))
+           (define-values (expr xforms-in-scope) (expand/top-level (car exprs) xforms))
+           (cond
+             [(define-syntaxes-form? expr)
+              (check-define-syntaxes/values-form! 'define-syntaxes expr)
+              (define-values (ids rhs)
+                (let ([ids (define-syntaxes/values-identifiers expr)])
+                  (check-duplicate-identifier! expr 'define-syntaxes xform-ids ids)
+                  (values ids (define-syntaxes/values-expr expr))))
+              (define results
+                (let ([rhs* (expand/expr rhs xforms)])
+                  (eval/values (syntax->datum rhs*) env $module-boot-expander?)))
+              (if (= (length ids) (length results))
+                  (let bind-xforms ([ids ids] [results results] [xforms xforms] [xform-ids xform-ids])
+                    (cond
+                      [(null? ids)
+                       (loop (cdr exprs) xforms define-ids xform-ids)]
+                      [else
+                       (define id (car ids))
+                       (define xform (car results))
+                       (cond
+                         [(procedure? xform)
+                          (define binding (cons id (list xform xforms)))
+                          (define xforms*
+                            (let update ([to-update xforms])
+                              (cond [(null? to-update) null]
+                                    [(member (caar to-update) xform-ids)
+                                     (cons
+                                       (cons (caar to-update) (list (cadar to-update) xforms))
+                                       (update (cdr to-update)))]
+                                    [else
+                                     (cons (car to-update) (update (cdr to-update)))])))
+                          (bind-xforms (cdr ids)
+                                       (cdr results)
+                                       (cons binding xforms*)
+                                       (cons id xform-ids))]
+                         [else
+                          (error 'define-syntaxes "expected a procedure? received" xform)])]))
+                  (error 'define-syntaxes "result arity mismatch" "expected"
+                         (length ids) "received" (length results)))]
+             [(define-values-form? expr)
+              (check-define-syntaxes/values-form! 'define-values expr)
+              (define ids (define-syntaxes/values-identifiers expr))
+              (check-duplicate-identifier! expr 'define-values define-ids ids)
+              (define-values (exprs* xforms*) (loop (cdr exprs) xforms (append ids define-ids) xform-ids))
+              (values (cons expr exprs*) xforms*)]
+             [(begin-form? expr)
+              (check-begin-form! expr)
+              (loop (append (cdr (syntax->list expr)) (cdr exprs)) xforms define-ids xform-ids)]
+             [else
+              (define expr* (expand/expr expr xforms-in-scope))
+              (define-values (exprs* xforms*) (loop (cdr exprs) xforms define-ids xform-ids))
+              (values (cons expr* exprs*) xforms*)])])))
     
     ; Any `define-values` form is deferred
     ; List of Expr, List of Xform -> List of Expr

--- a/src/boot/s/module.min
+++ b/src/boot/s/module.min
@@ -130,66 +130,13 @@
 
   ;; expand phase
   (define ($expand exprs)
-    ;; testing
-    (define-values (test-exprs test-xforms)
-            (expand/module exprs imported-xforms
-                           ($base-stx-env ($eval-environment $base-env imported))))
-    ; (writeln (list path test-exprs test-xforms))
-    ;; setup environment
+    ; setup environment
     (set! stx-env ($base-stx-env ($eval-environment $base-env imported)))
-    ;; apply transformers
-    (set! module-xforms imported-xforms)
-    (let loop ([exprs exprs] [acc '()])
-      (cond
-        [(null? exprs)
-         (reverse acc)]
-        [else
-         (define expanded (expand (car exprs) module-xforms stx-env))
-         (define expanded* (syntax-e expanded))
-         (cond
-           [(and (pair? expanded*) (eq? (syntax-e (car expanded*)) 'define-syntaxes))
-            (define (panic!) (syntax-error 'define-syntaxes "bad syntax" expanded))
-            (define rib (cdr expanded*))
-            (cond
-              [(and (pair? rib) (list? (syntax-e (car rib))))
-               (define xform-names
-                 (let loop ([names (syntax-e (car rib))] [acc '()])
-                   (if (null? names)
-                       (reverse acc)
-                       (loop (cdr names) (cons (syntax-e (car names)) acc)))))
-               (define rib (cdr rib))
-               (cond
-                 [(and (pair? rib) (null? (cdr rib)))
-                  (define expr (syntax->datum (car rib)))
-                  (define old-expander? (boot-expander?))
-                  (call-with-values
-                     (lambda ()
-                       (boot-expander? $module-boot-expander?)
-                       (eval expr stx-env))
-                     (lambda results
-                       (boot-expander? old-expander?)
-                       (if (not (= (length xform-names) (length results)))
-                           (error 'define-syntaxes "result arity mismatch" "expected"
-                                  (length xform-names) "received" (length results))
-                           (let loop ([xform-names xform-names] [results results])
-                             (if (null? xform-names)
-                                 (void)
-                                 (let ([xform-name (car xform-names)]
-                                       [xform (car results)])
-                                   (cond
-                                     [(procedure? xform)
-                                      (define binding (cons xform-name xform))
-                                      (set! module-xforms (cons binding module-xforms))
-                                      (loop (cdr xform-names) (cdr results))]
-                                     [else
-                                      (error 'define-syntaxes "expected a procedure? received" xform)])))))))]
-                 [else
-                  (panic!)])]
-               [else
-                (panic!)])
-            (loop (cdr exprs) acc)]
-           [else
-            (loop (cdr exprs) (cons expanded acc))])])))
+    ; testing
+    (define-values (exprs* xforms*) (expand/module exprs imported-xforms stx-env))
+    ; update
+    (set! module-xforms xforms*)
+    exprs*)
 
   ;; apply non-eval phases
   (define raw-exprs ($read))

--- a/src/boot/s/module.min
+++ b/src/boot/s/module.min
@@ -26,13 +26,12 @@
                                (if (null? assoc)
                                    #f
                                    (if (eq? (caar assoc) k)
-                                       (cdar assoc)
+                                       (cadar assoc)
                                        (loop (cdr assoc)))))])
               (loop $expander-pattern-vars))
             (error 'get-pattern-variable
                    "expected symbol?" k))))
     env))
-
 
 ;; Module caches
 ;;  name -> (exporting xforms, exporting values)
@@ -87,8 +86,8 @@
                     (import path)
                     (define from-module (assoc path $module-table))
                     (set! imported-modules (cons path imported-modules))
-                    (set! imported-xforms (append (car from-module) imported-xforms))
-                    (set! imported (append (cdr from-module) imported))
+                    (set! imported-xforms (merge-xforms (car from-module) imported-xforms))
+                    (set! imported (append (cdr from-module) imported)) ; TODO: dedup
                     (loop2 (cdr imports))]
                    [else
                     (error 'import "bad syntax")])]

--- a/src/boot/s/module.min
+++ b/src/boot/s/module.min
@@ -130,6 +130,11 @@
 
   ;; expand phase
   (define ($expand exprs)
+    ;; testing
+    (define-values (test-exprs test-xforms)
+            (expand/module exprs imported-xforms
+                           ($base-stx-env ($eval-environment $base-env imported))))
+    ; (writeln (list path test-exprs test-xforms))
     ;; setup environment
     (set! stx-env ($base-stx-env ($eval-environment $base-env imported)))
     ;; apply transformers

--- a/src/boot/s/module.min
+++ b/src/boot/s/module.min
@@ -221,31 +221,31 @@
 
 ;; REPL with env
 (define ($repl xforms stx-env env)
-  (let loop ()
+  (let loop ([xforms xforms])
     ;; read
     (display "> ")
-    (define stx (read))
-    (cond [(eof-object? stx) (exit)])
+    (define expr (read))
+    (cond [(eof-object? expr) (exit)])
     ;; expand
-    (define stx* (expand stx xforms stx-env))
-    (define old-expander? (boot-expander?))
-    ;; evaluate and display
-    (call-with-values
-      (lambda ()
-        (let ([expr (syntax->datum stx*)])
-          (boot-expander? $module-boot-expander?)
-          (eval expr env)))
-      (lambda results
-        (boot-expander? old-expander?)
-        (let loop ([results results])
-          (cond
-            [(null? results) (void)]
-            [(void? (car results)) (loop (cdr results))]
-            [else
-             (writeln (car results))
-             (loop (cdr results))]))))
-    ;; loop
-    (loop)))
+    (let-values ([(expr* xforms*) (expand expr xforms stx-env)])
+      (define old-expander? (boot-expander?))
+      ;; evaluate and display
+      (call-with-values
+        (lambda ()
+          (let ([expr (syntax->datum expr*)])
+            (boot-expander? $module-boot-expander?)
+            (eval expr env)))
+        (lambda results
+          (boot-expander? old-expander?)
+          (let loop ([results results])
+            (cond
+              [(null? results) (void)]
+              [(void? (car results)) (loop (cdr results))]
+              [else
+              (writeln (car results))
+              (loop (cdr results))]))))
+      ;; loop
+      (loop xforms*))))
 
 (define ($load-or-import name print-handler result-handler)
   ;; resolve path

--- a/src/boot/s/read.min
+++ b/src/boot/s/read.min
@@ -263,14 +263,17 @@
              [(eq? c #\\)
               (read-char p)
               (loop (cons #\\ acc))]
-             [else
-              (error 'read "unknown escape character" c)])]
              [(eq? c #\")
               (read-char p)
-              (reverse acc)]
+              (loop (cons #\" acc))]
              [else
-              (read-char p)
-              (loop (cons c acc))])))
+              (error 'read "unknown escape character" c)])]
+          [(eq? c #\")
+           (read-char p)
+           (reverse acc)]
+          [else
+           (read-char p)
+           (loop (cons c acc))])))
 
     ;; Main loop
 

--- a/src/boot/test/case-lambda.min
+++ b/src/boot/test/case-lambda.min
@@ -1,0 +1,41 @@
+;;;
+;;; Tests for 'case-lambda'
+;;;
+
+(import "../lib/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+; degenerate case
+(check-equal? ((case-lambda [() 1])) 1)
+(check-equal? ((case-lambda [(a) a]) 1) 1)
+(check-equal? ((case-lambda [(a b) (+ a b)]) 1 2) 3)
+(check-equal? ((case-lambda [(a b c) (+ a b c)]) 1 2 3) 6)
+
+; degenerate case (rest argument)
+(check-equal? ((case-lambda [a a])) '())
+(check-equal? ((case-lambda [a a]) 1) '(1))
+(check-equal? ((case-lambda [a a]) 1 2 3) '(1 2 3))
+(check-equal? ((case-lambda [(a . b) (list a b)]) 1) '(1 ()))
+(check-equal? ((case-lambda [(a . b) (list a b)]) 1 2) '(1 (2)))
+(check-equal? ((case-lambda [(a . b) (list a b)]) 1 2 3) '(1 (2 3)))
+(check-equal? ((case-lambda [(a b . c) (list a b c)]) 1 2) '(1 2 ()))
+(check-equal? ((case-lambda [(a b . c) (list a b c)]) 1 2 3) '(1 2 (3)))
+(check-equal? ((case-lambda [(a b . c) (list a b c)]) 1 2 3 4) '(1 2 (3 4)))
+
+; multi-case simple
+(check-equal? ((case-lambda [() 0] [(a) 1] [(a b) 2])) 0)
+(check-equal? ((case-lambda [() 0] [(a) 1] [(a b) 2]) 1) 1)
+(check-equal? ((case-lambda [() 0] [(a) 1] [(a b) 2]) 1 2) 2)
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/src/boot/test/case.min
+++ b/src/boot/test/case.min
@@ -1,0 +1,39 @@
+;;;
+;;; Tests for 'case'
+;;;
+
+(import "../lib/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+; empty case
+(check-equal? (case 1) (void))
+(check-equal? (case '()) (void))
+
+; only-else case
+(check-equal? (case 1 [else #t]) #t)
+(check-equal? (case '() [else #f]) #f)
+
+; equal datum
+(check-equal? (case 1 [(1) #t] [else #f]) #t)
+; (check-equal? (case null [(null) #t] [else #f]) #t)
+
+; no keys
+(check-equal? (case 1 [() 1] [else #t]) #t)
+(check-equal? (case 1 [() 1] [() 2] [else #t]) #t)
+
+; fall through
+(check-equal? (case 1 [(2) 2] [(3) 3]) (void))
+(check-equal? (case 1 [(2) 2] [(3) 3] [(4) 4]) (void))
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/src/boot/test/case.min
+++ b/src/boot/test/case.min
@@ -25,7 +25,7 @@
 
 ; equal datum
 (check-equal? (case 1 [(1) #t] [else #f]) #t)
-; (check-equal? (case null [(null) #t] [else #f]) #t)
+(check-equal? (case null [(()) #t] [else #f]) #t)
 
 ; no keys
 (check-equal? (case 1 [() 1] [else #t]) #t)

--- a/src/boot/test/stxcase.min
+++ b/src/boot/test/stxcase.min
@@ -63,6 +63,12 @@
     [(_ a ... b c . d) #''(b c (a ...) d)]
     [_ #''bad]))
 
+(define-syntax (macro-11 stx)
+  (syntax-case stx ()
+    [(_ a b c d e ...) #'(+ a b c)]
+    [(_ a b) #'(+ a b c)]
+    [_ #''bad]))
+
 (check-equal? (macro-1 2) 1)
 (check-equal? (macro-1 2) 1)
 (check-equal? (macro-2 1) 1)
@@ -96,6 +102,10 @@
 (check-equal? (macro-10 1 2 3) '(2 3 (1) ()))
 (check-equal? (macro-10 1 2 3 4) '(3 4 (1 2) ()))
 (check-equal? (macro-10 1 2 3 4 . 5) '(3 4 (1 2) 5))
+
+(check-equal? (macro-11) 'bad)
+(check-equal? (macro-11 1) 'bad)
+(check-equal? (macro-11 1 2 3) 'bad)
 
 ;; actual Scheme macros
 


### PR DESCRIPTION
This PR fixes the expander by having separate top-level and expression level expanders. Upon applying a transformer, the expander introduces a new scope that includes the transforms in-scope where the transformer is defined. Thus, a transformer need not be exported if it is only used in a recursive expansion.