### PR TITLE
Support for hash-tables

### DIFF
--- a/src/boot/Makefile
+++ b/src/boot/Makefile
@@ -30,7 +30,9 @@ READLINK	:= readlink -f
 .PRECIOUS: $(BUILD_DIR)/. $(BUILD_DIR)%/.
 .SECONDEXPANSION: $(BUILD_DIR)/%.o
 
-boot: $(CONFIG) $(OBJS)
+all: minim
+
+minim: $(CONFIG) $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(ENTRY) $(LDFLAGS) -o minim
 
 profile:

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -150,6 +150,11 @@ void populate_env(minim_object *env) {
 
     add_procedure("hashtable?", is_hashtable_proc, 1, 1);
     add_procedure("make-eq-hashtable", make_eq_hashtable_proc, 0, 0);   // TODO: allow size hint?
+    add_procedure("hashtable-size", hashtable_size_proc, 1, 1);
+    add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
+
+    add_procedure("eq-hash", eq_hash_proc, 1, 1);
+    add_procedure("equal-hash", equal_hash_proc, 1, 1);
     
     add_procedure("syntax?", is_syntax_proc, 1, 1);
     add_procedure("syntax-e", syntax_e_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -158,6 +158,8 @@ void populate_env(minim_object *env) {
     add_procedure("hashtable-update!", hashtable_update_proc, 3, 4);
     add_procedure("hashtable-ref", hashtable_ref_proc, 2, 3);
     add_procedure("hashtable-keys", hashtable_keys_proc, 1, 1);
+    add_procedure("hashtable-copy", hashtable_copy_proc, 1, 1);     // TODO: set mutability
+    add_procedure("hashtable-clear!", hashtable_clear_proc, 1, 1);
 
     add_procedure("eq-hash", eq_hash_proc, 1, 1);
     add_procedure("equal-hash", equal_hash_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -155,6 +155,7 @@ void populate_env(minim_object *env) {
     add_procedure("hashtable-contains?", hashtable_contains_proc, 2, 2);
     add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
     add_procedure("hashtable-delete!", hashtable_delete_proc, 2, 2);
+    add_procedure("hashtable-update!", hashtable_update_proc, 3, 3);
     add_procedure("hashtable-ref", hashtable_ref_proc, 2, 2);
     add_procedure("hashtable-keys", hashtable_keys_proc, 1, 1);
 

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -155,8 +155,8 @@ void populate_env(minim_object *env) {
     add_procedure("hashtable-contains?", hashtable_contains_proc, 2, 2);
     add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
     add_procedure("hashtable-delete!", hashtable_delete_proc, 2, 2);
-    add_procedure("hashtable-update!", hashtable_update_proc, 3, 3);
-    add_procedure("hashtable-ref", hashtable_ref_proc, 2, 2);
+    add_procedure("hashtable-update!", hashtable_update_proc, 3, 4);
+    add_procedure("hashtable-ref", hashtable_ref_proc, 2, 3);
     add_procedure("hashtable-keys", hashtable_keys_proc, 1, 1);
 
     add_procedure("eq-hash", eq_hash_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -152,6 +152,7 @@ void populate_env(minim_object *env) {
     add_procedure("make-eq-hashtable", make_eq_hashtable_proc, 0, 0);   // TODO: allow size hint?
     add_procedure("hashtable-size", hashtable_size_proc, 1, 1);
     add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
+    add_procedure("hashtable-ref", hashtable_ref_proc, 2, 2);
 
     add_procedure("eq-hash", eq_hash_proc, 1, 1);
     add_procedure("equal-hash", equal_hash_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -150,8 +150,11 @@ void populate_env(minim_object *env) {
 
     add_procedure("hashtable?", is_hashtable_proc, 1, 1);
     add_procedure("make-eq-hashtable", make_eq_hashtable_proc, 0, 0);   // TODO: allow size hint?
+    add_procedure("make-hashtable", make_hashtable_proc, 0, 0);         // TODO: allow size hint?
     add_procedure("hashtable-size", hashtable_size_proc, 1, 1);
+    add_procedure("hashtable-contains?", hashtable_contains_proc, 2, 2);
     add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
+    add_procedure("hashtable-delete!", hashtable_delete_proc, 2, 2);
     add_procedure("hashtable-ref", hashtable_ref_proc, 2, 2);
 
     add_procedure("eq-hash", eq_hash_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -147,6 +147,9 @@ void populate_env(minim_object *env) {
     add_procedure("string-ref", string_ref_proc, 2, 2);
     add_procedure("string-set!", string_set_proc, 3, 3);
     add_procedure("string-append", string_append_proc, 0, ARG_MAX);
+
+    add_procedure("hashtable?", is_hashtable_proc, 1, 1);
+    add_procedure("make-eq-hashtable", make_eq_hashtable_proc, 0, 0);   // TODO: allow size hint?
     
     add_procedure("syntax?", is_syntax_proc, 1, 1);
     add_procedure("syntax-e", syntax_e_proc, 1, 1);

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -156,6 +156,7 @@ void populate_env(minim_object *env) {
     add_procedure("hashtable-set!", hashtable_set_proc, 3, 3);
     add_procedure("hashtable-delete!", hashtable_delete_proc, 2, 2);
     add_procedure("hashtable-ref", hashtable_ref_proc, 2, 2);
+    add_procedure("hashtable-keys", hashtable_keys_proc, 1, 1);
 
     add_procedure("eq-hash", eq_hash_proc, 1, 1);
     add_procedure("equal-hash", equal_hash_proc, 1, 1);

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -207,6 +207,22 @@ static minim_object *hashtable_find(minim_object *ht, minim_object *k) {
     return minim_null;
 }
 
+static minim_object *hashtable_keys(minim_object *ht) {
+    minim_object *b, *ks;
+    uint64_t i;
+
+    ks = minim_null;
+    for (i = 0; i < minim_hashtable_alloc(ht); ++i) {
+        b = minim_hashtable_bucket(ht, i);
+        if (b) {
+            for (; !minim_is_null(b); b = minim_cdr(b))
+                ks = make_pair(minim_caar(b), ks);
+        }
+    }
+
+    return ks;
+}
+
 //
 //  Primitives
 //
@@ -301,6 +317,16 @@ minim_object *hashtable_ref_proc(minim_object *args) {
     }
 
     return minim_cdr(b);
+}
+
+minim_object *hashtable_keys_proc(minim_object *args) {
+    // (-> hashtable (listof any))
+    minim_object *ht;
+
+    ht = minim_car(args);
+    if (!minim_is_hashtable(ht))
+        bad_type_exn("hashtable-keys", "hashtable?", ht);
+    return hashtable_keys(ht);
 }
 
 minim_object *eq_hash_proc(minim_object *args) {

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -1,0 +1,100 @@
+/*
+    Hashtables
+*/
+
+#include "../minim.h"
+
+#define hash_init       5381
+
+#define MINIM_INTERN_TABLE_LOAD_FACTOR     0.75
+#define start_size_ptr                     (&bucket_sizes[0])
+#define load_factor(s, a)                  ((double)(s) / (double)(a))
+
+minim_object *make_hashtable(void *hash_fn) {
+    minim_hashtable_object *o = GC_alloc(sizeof(minim_hashtable_object));
+    o->type = MINIM_HASHTABLE_TYPE;
+    o->alloc_ptr = start_size_ptr;
+    o->alloc = *o->alloc_ptr;
+    o->size = 0;
+    o->buckets = GC_calloc(o->alloc, sizeof(minim_object*));
+    o->hash_fn = hash_fn;
+    return ((minim_object *) o);
+}
+
+static uint32_t hash_bytes(const void *data, size_t len, uint32_t hash0) {
+    const char *str;
+    size_t i;
+    uint32_t hash;
+    
+    hash = hash0;
+    str = (const char*) data;
+    for (i = 0; i < len; ++i)
+        hash = ((hash << 5) + hash) + str[i]; /* hash * 33 + c */
+
+    return hash;
+}
+
+
+uint32_t eq_hash2(minim_object *o, uint32_t hash) {
+    switch (o->type)
+    {
+    case MINIM_FIXNUM_TYPE:
+        return hash_bytes(&minim_fixnum(o), sizeof(minim_fixnum(o)), hash);
+    case MINIM_CHAR_TYPE:
+        return hash_bytes(&minim_char(o), sizeof(minim_char(o)), hash);
+    default:
+        return hash_bytes(&o, sizeof(minim_object *), hash);
+    }
+}
+
+static uint32_t equal_hash2(minim_object *o, uint32_t hash) {
+    minim_object *it;
+    long i;
+
+    switch (o->type)
+    {
+    case MINIM_SYMBOL_TYPE:
+        return hash_bytes(&minim_symbol(o), strlen(minim_symbol(o)), hash);
+    case MINIM_STRING_TYPE:
+        return hash_bytes(&minim_string(o), strlen(minim_string(o)), hash);
+    case MINIM_PAIR_TYPE:
+        return equal_hash2(minim_cdr(o), equal_hash2(minim_car(o), hash));
+    case MINIM_VECTOR_TYPE:
+        for (i = 0; i < minim_vector_len(o); ++i)
+            hash = equal_hash2(minim_vector_ref(o, i), hash);
+        return hash;
+    case MINIM_HASHTABLE_TYPE:
+        for (i = 0; i < minim_hashtable_alloc(o); ++i) {
+            it = minim_hashtable_buckets(o)[i];
+            if (it) {
+                for (; !minim_is_null(it); it = minim_cdr(it)) {
+                    hash = equal_hash2(minim_caar(it), hash);
+                    hash = equal_hash2(minim_cdar(it), hash);
+                }
+            }
+        }
+        return hash;
+    default:
+        return eq_hash2(o, hash);
+    }
+}
+
+uint32_t eq_hash(minim_object *o) {
+    return eq_hash2(o, hash_init);
+}
+
+uint32_t equal_hash(minim_object *o) {
+    return equal_hash2(o, hash_init);
+}
+
+//
+//  Primitives
+//
+
+minim_object *is_hashtable_proc(minim_object *args) {
+    return (minim_is_hashtable(minim_car(args)) ? minim_true : minim_false);
+}
+
+minim_object *make_eq_hashtable_proc(minim_object *args) {
+    return make_hashtable(eq_hash);
+}

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -4,38 +4,43 @@
 
 #include "../minim.h"
 
-#define hash_init       5381
+#define hash_init       5381L
 
-#define MINIM_INTERN_TABLE_LOAD_FACTOR     0.75
-#define start_size_ptr                     (&bucket_sizes[0])
-#define load_factor(s, a)                  ((double)(s) / (double)(a))
+#define MINIM_HASHTABLE_LOAD_FACTOR         0.75
+#define start_size_ptr                      (&bucket_sizes[0])
+#define load_factor(s, a)                   ((double)(s) / (double)(a))
 
-minim_object *make_hashtable(void *hash_fn) {
-    minim_hashtable_object *o = GC_alloc(sizeof(minim_hashtable_object));
+minim_object *make_hashtable(minim_object *hash_fn, minim_object *equiv_fn) {
+    minim_hashtable_object *o;
+    
+    o = GC_alloc(sizeof(minim_hashtable_object));
     o->type = MINIM_HASHTABLE_TYPE;
     o->alloc_ptr = start_size_ptr;
     o->alloc = *o->alloc_ptr;
     o->size = 0;
     o->buckets = GC_calloc(o->alloc, sizeof(minim_object*));
-    o->hash_fn = hash_fn;
+    o->hash = hash_fn;
+    o->equiv = equiv_fn;
+
     return ((minim_object *) o);
 }
 
-static uint32_t hash_bytes(const void *data, size_t len, uint32_t hash0) {
+static uint64_t hash_bytes(const void *data, size_t len, uint64_t hash0) {
     const char *str;
+    uint64_t hash;
     size_t i;
-    uint32_t hash;
     
     hash = hash0;
     str = (const char*) data;
     for (i = 0; i < len; ++i)
-        hash = ((hash << 5) + hash) + str[i]; /* hash * 33 + c */
+        hash = ((hash << 6) + hash) + str[i]; /* hash * 65 + c */
 
-    return hash;
+    // preserve only 62 bits
+    return hash >> 2;
 }
 
 
-uint32_t eq_hash2(minim_object *o, uint32_t hash) {
+uint64_t eq_hash2(minim_object *o, uint64_t hash) {
     switch (o->type)
     {
     case MINIM_FIXNUM_TYPE:
@@ -47,7 +52,7 @@ uint32_t eq_hash2(minim_object *o, uint32_t hash) {
     }
 }
 
-static uint32_t equal_hash2(minim_object *o, uint32_t hash) {
+static uint64_t equal_hash2(minim_object *o, uint64_t hash) {
     minim_object *it;
     long i;
 
@@ -65,7 +70,7 @@ static uint32_t equal_hash2(minim_object *o, uint32_t hash) {
         return hash;
     case MINIM_HASHTABLE_TYPE:
         for (i = 0; i < minim_hashtable_alloc(o); ++i) {
-            it = minim_hashtable_buckets(o)[i];
+            it = minim_hashtable_bucket(o, i);
             if (it) {
                 for (; !minim_is_null(it); it = minim_cdr(it)) {
                     hash = equal_hash2(minim_caar(it), hash);
@@ -79,12 +84,86 @@ static uint32_t equal_hash2(minim_object *o, uint32_t hash) {
     }
 }
 
-uint32_t eq_hash(minim_object *o) {
+static uint64_t eq_hash(minim_object *o) {
     return eq_hash2(o, hash_init);
 }
 
-uint32_t equal_hash(minim_object *o) {
+static uint64_t equal_hash(minim_object *o) {
     return equal_hash2(o, hash_init);
+}
+
+static uint64_t hash_key(minim_object *ht, minim_object *k) {
+    minim_object *i, *env;
+
+    env = global_env(current_thread());   // TODO: this seems problematic
+    i = call_with_args(minim_hashtable_hash(ht), make_pair(k, minim_null), env);
+    if (!minim_is_fixnum(i)) {
+        fprintf(stderr, "hash function associated with hash table ");
+        write_object(stderr, ht);
+        fprintf(stderr, " did not return a fixnum");
+        exit(1);
+    }
+
+    return minim_fixnum(i);
+}
+
+static int key_equiv(minim_object *ht, minim_object *k1, minim_object *k2) {
+    minim_object *eq, *env;
+
+    env = global_env(current_thread());   // TODO: this seems problematic
+    eq = call_with_args(minim_hashtable_equiv(ht), make_pair(k1, make_pair(k2, minim_null)), env);
+    return !minim_is_false(eq);
+}
+
+static void hashtable_opt_resize(minim_object *ht) {
+    minim_object **buckets, *it;
+    uint64_t *alloc_ptr;
+    uint64_t alloc, sz, i, idx;
+
+    sz = minim_hashtable_size(ht);
+    alloc = minim_hashtable_alloc(ht);
+    if (load_factor(sz, alloc) > MINIM_HASHTABLE_LOAD_FACTOR) {
+        alloc_ptr = minim_hashtable_alloc_ptr(ht);
+        for (; load_factor(sz, *alloc_ptr) > MINIM_HASHTABLE_LOAD_FACTOR; ++alloc_ptr);
+
+        buckets = GC_calloc(*alloc_ptr, sizeof(minim_object *));
+        for (i = 0; i < minim_hashtable_alloc(ht); ++i) {
+            it = minim_hashtable_bucket(ht, i);
+            if (it) {
+                for (; !minim_is_null(it); it = minim_cdr(it)) {
+                    idx = hash_key(ht, minim_caar(it)) % *alloc_ptr;
+                    buckets[idx] = make_pair(make_pair(minim_caar(it), minim_cdar(it)),
+                                             buckets[idx] ? buckets[idx] : minim_null);
+                }
+            }
+        }
+
+        minim_hashtable_alloc_ptr(ht) = alloc_ptr;
+        minim_hashtable_alloc(ht) = *alloc_ptr;
+        minim_hashtable_buckets(ht) = buckets;
+    }
+}
+
+static void hashtable_set(minim_object *ht, minim_object *k, minim_object *v) {
+    minim_object *b, *bi;
+    uint64_t i;
+
+    i = hash_key(ht, k) % minim_hashtable_alloc(ht);
+    b = minim_hashtable_bucket(ht, i);
+    if (b) {
+        for (bi = b; !minim_is_null(bi); bi = minim_cdr(bi)) {
+            if (key_equiv(ht, minim_caar(bi), k)) {
+                minim_cdar(bi) = v;
+                return;
+            }
+        }
+    } else {
+        b = minim_null;
+    }
+
+    hashtable_opt_resize(ht);
+    minim_hashtable_bucket(ht, i) = make_pair(make_pair(k, v), b);
+    ++minim_hashtable_size(ht);
 }
 
 //
@@ -92,9 +171,44 @@ uint32_t equal_hash(minim_object *o) {
 //
 
 minim_object *is_hashtable_proc(minim_object *args) {
+    // (-> any boolean)
     return (minim_is_hashtable(minim_car(args)) ? minim_true : minim_false);
 }
 
 minim_object *make_eq_hashtable_proc(minim_object *args) {
-    return make_hashtable(eq_hash);
+    // (-> hashtable)
+    return make_hashtable(make_prim_proc(eq_hash_proc, "eq-hash", 1, 1),
+                          make_prim_proc(eq_proc, "eq?", 2, 2));
+}
+
+minim_object *hashtable_size_proc(minim_object *args) {
+    // (-> hashtable any any void)
+    minim_object *ht;
+
+    ht = minim_car(args);
+    if (!minim_is_hashtable(ht))
+        bad_type_exn("hashtable-set!", "hashtable?", ht);
+    return make_fixnum(minim_hashtable_size(ht));
+}
+
+minim_object *hashtable_set_proc(minim_object *args) {
+    // (-> hashtable any any void)
+    minim_object *ht, *k, *v;
+
+    ht = minim_car(args);
+    if (!minim_is_hashtable(ht))
+        bad_type_exn("hashtable-set!", "hashtable?", ht);
+
+    k = minim_cadr(args);
+    v = minim_car(minim_cddr(args));
+    hashtable_set(ht, k, v);
+    return minim_void;
+}
+
+minim_object *eq_hash_proc(minim_object *args) {
+    return make_fixnum(eq_hash(minim_car(args)));
+}
+
+minim_object *equal_hash_proc(minim_object *args) {
+    return make_fixnum(equal_hash(minim_car(args)));
 }

--- a/src/boot/c/io.c
+++ b/src/boot/c/io.c
@@ -376,7 +376,9 @@ static void write_pair(FILE *out, minim_pair_object *p, int quote, int display) 
 }
 
 void write_object2(FILE *out, minim_object *o, int quote, int display) {
+    minim_object *it;
     char *str;
+    long i;
 
     switch (o->type) {
     case MINIM_NULL_TYPE:
@@ -463,6 +465,26 @@ void write_object2(FILE *out, minim_object *o, int quote, int display) {
                 write_object2(out, minim_vector_ref(o, i), 1, display);
             }
             fputc(')', out);
+        }
+        break;
+    case MINIM_HASHTABLE_TYPE:
+        if (minim_hashtable_size(o) == 0) {
+            fprintf(out, "#<hashtable>");
+        } else {
+            fprintf(out, "#<hashtable ");
+            for (i = 0; i < minim_hashtable_alloc(o); ++i) {
+                it = minim_hashtable_buckets(o)[i];
+                if (it) {
+                    for (; !minim_is_null(it); it = minim_cdr(it)) {
+                        fputc('(', out);
+                        write_object2(out, minim_caar(it), 1, display);
+                        fputs(" . ", out);
+                        write_object2(out, minim_cdar(it), 1, display);
+                        fputc(')', out);
+                    }
+                }
+            }
+            fputc('>', out);
         }
         break;
     case MINIM_PRIM_PROC_TYPE:

--- a/src/boot/c/io.c
+++ b/src/boot/c/io.c
@@ -471,12 +471,12 @@ void write_object2(FILE *out, minim_object *o, int quote, int display) {
         if (minim_hashtable_size(o) == 0) {
             fprintf(out, "#<hashtable>");
         } else {
-            fprintf(out, "#<hashtable ");
+            fprintf(out, "#<hashtable");
             for (i = 0; i < minim_hashtable_alloc(o); ++i) {
-                it = minim_hashtable_buckets(o)[i];
+                it = minim_hashtable_bucket(o, i);
                 if (it) {
                     for (; !minim_is_null(it); it = minim_cdr(it)) {
-                        fputc('(', out);
+                        fputs(" (", out);
                         write_object2(out, minim_caar(it), 1, display);
                         fputs(" . ", out);
                         write_object2(out, minim_cdar(it), 1, display);

--- a/src/boot/c/object.c
+++ b/src/boot/c/object.c
@@ -77,6 +77,12 @@ int minim_is_equal(minim_object *a, minim_object *b) {
 
         return 1;
 
+    case MINIM_HASHTABLE_TYPE:
+        if (minim_hashtable_size(a) != minim_hashtable_size(b))
+            return 0;
+
+        return 0;
+
     default:
         return 0;
     }

--- a/src/boot/c/symbol.c
+++ b/src/boot/c/symbol.c
@@ -5,12 +5,10 @@
     Symbol/string interner
 */
 
-#include <stdint.h>
-
 #include "../minim.h"
 
 // copied from ChezScheme
-static size_t bucket_sizes[] = {
+size_t bucket_sizes[] = {
     13,
     29,
     59,
@@ -81,7 +79,6 @@ static size_t bucket_sizes[] = {
     if (load_factor((i)->size, (i)->alloc) > MINIM_INTERN_TABLE_LOAD_FACTOR)    \
         intern_table_resize(i);                                                 \
 }
-
 
 #define new_bucket(b, s, n) {                       \
     (b) = GC_alloc(sizeof(intern_table_bucket));    \

--- a/src/boot/c/system.c
+++ b/src/boot/c/system.c
@@ -140,6 +140,7 @@ minim_object *error_proc(minim_object *args) {
 
 minim_object *exit_proc(minim_object *args) {
     // (-> any)
+    GC_finalize();
     exit(0);
 }
 

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -535,6 +535,7 @@ DEFINE_PRIM_PROC(hashtable_size);
 DEFINE_PRIM_PROC(hashtable_contains);
 DEFINE_PRIM_PROC(hashtable_set);
 DEFINE_PRIM_PROC(hashtable_delete);
+DEFINE_PRIM_PROC(hashtable_update);
 DEFINE_PRIM_PROC(hashtable_ref);
 DEFINE_PRIM_PROC(hashtable_keys);
 // hash functions

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -530,8 +530,11 @@ DEFINE_PRIM_PROC(string_to_symbol);
 // hashtable
 DEFINE_PRIM_PROC(is_hashtable);
 DEFINE_PRIM_PROC(make_eq_hashtable);
+DEFINE_PRIM_PROC(make_hashtable);
 DEFINE_PRIM_PROC(hashtable_size);
+DEFINE_PRIM_PROC(hashtable_contains);
 DEFINE_PRIM_PROC(hashtable_set);
+DEFINE_PRIM_PROC(hashtable_delete);
 DEFINE_PRIM_PROC(hashtable_ref);
 // hash functions
 DEFINE_PRIM_PROC(eq_hash);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -536,6 +536,7 @@ DEFINE_PRIM_PROC(hashtable_contains);
 DEFINE_PRIM_PROC(hashtable_set);
 DEFINE_PRIM_PROC(hashtable_delete);
 DEFINE_PRIM_PROC(hashtable_ref);
+DEFINE_PRIM_PROC(hashtable_keys);
 // hash functions
 DEFINE_PRIM_PROC(eq_hash);
 DEFINE_PRIM_PROC(equal_hash);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -23,7 +23,6 @@
 
 #define INIT_VALUES_BUFFER_LEN      10
 
-
 // Arity
 
 typedef enum {
@@ -122,7 +121,7 @@ typedef struct {
 typedef struct {
     minim_object_type type;
     struct proc_arity arity;
-    minim_object *(*fn)(minim_object *args);
+    minim_object *(*fn)(minim_object *);
     char *name;
 } minim_prim_proc_object;
 
@@ -149,10 +148,10 @@ typedef struct {
 
 typedef struct {
     minim_object_type type;
+    minim_object *hash, *equiv;
     minim_object **buckets;
     size_t *alloc_ptr;
     size_t alloc, size;
-    void *hash_fn;
 } minim_hashtable_object;
 
 typedef struct {
@@ -256,8 +255,12 @@ extern minim_object *quote_syntax_symbol;
 #define minim_syntax_loc(x)     (((minim_syntax_object *) (x))->loc)
 
 #define minim_hashtable_buckets(x)      (((minim_hashtable_object *) (x))->buckets)
+#define minim_hashtable_bucket(x, i)    ((((minim_hashtable_object *) (x))->buckets)[i])
+#define minim_hashtable_alloc_ptr(x)    (((minim_hashtable_object *) (x))->alloc_ptr)
 #define minim_hashtable_alloc(x)        (((minim_hashtable_object *) (x))->alloc)
 #define minim_hashtable_size(x)         (((minim_hashtable_object *) (x))->size)
+#define minim_hashtable_hash(x)         (((minim_hashtable_object *) (x))->hash)
+#define minim_hashtable_equiv(x)        (((minim_hashtable_object *) (x))->equiv)
 
 #define minim_pattern_var_value(x)      (((minim_pattern_var_object *) (x))->value)
 #define minim_pattern_var_depth(x)      (((minim_pattern_var_object *) (x))->depth)
@@ -287,7 +290,7 @@ minim_object *make_string(const char *s);
 minim_object *make_string2(char *s);
 minim_object *make_pair(minim_object *car, minim_object *cdr);
 minim_object *make_vector(long len, minim_object *init);
-minim_object *make_hashtable(void *hash_fn);
+minim_object *make_hashtable(minim_object *hash_fn, minim_object *equiv_fn);
 minim_object *make_prim_proc(minim_prim_proc_t proc, char *name, short min_arity, short max_arity);
 minim_object *make_closure_proc(minim_object *args, minim_object *body, minim_object *env, short min_arity, short max_arity);
 minim_object *make_input_port(FILE *stream);
@@ -360,11 +363,6 @@ typedef struct intern_table {
 
 intern_table *make_intern_table();
 minim_object *intern_symbol(intern_table *itab, const char *sym);
-
-// Hashing
-
-uint32_t eq_hash(minim_object*);
-uint32_t equal_hash(minim_object*);
 
 // Threads
 
@@ -532,6 +530,11 @@ DEFINE_PRIM_PROC(string_to_symbol);
 // hashtable
 DEFINE_PRIM_PROC(is_hashtable);
 DEFINE_PRIM_PROC(make_eq_hashtable);
+DEFINE_PRIM_PROC(hashtable_size);
+DEFINE_PRIM_PROC(hashtable_set);
+// hash functions
+DEFINE_PRIM_PROC(eq_hash);
+DEFINE_PRIM_PROC(equal_hash);
 // environment
 DEFINE_PRIM_PROC(empty_environment);
 DEFINE_PRIM_PROC(extend_environment);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -532,6 +532,7 @@ DEFINE_PRIM_PROC(is_hashtable);
 DEFINE_PRIM_PROC(make_eq_hashtable);
 DEFINE_PRIM_PROC(hashtable_size);
 DEFINE_PRIM_PROC(hashtable_set);
+DEFINE_PRIM_PROC(hashtable_ref);
 // hash functions
 DEFINE_PRIM_PROC(eq_hash);
 DEFINE_PRIM_PROC(equal_hash);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -538,6 +538,8 @@ DEFINE_PRIM_PROC(hashtable_delete);
 DEFINE_PRIM_PROC(hashtable_update);
 DEFINE_PRIM_PROC(hashtable_ref);
 DEFINE_PRIM_PROC(hashtable_keys);
+DEFINE_PRIM_PROC(hashtable_copy);
+DEFINE_PRIM_PROC(hashtable_clear);
 // hash functions
 DEFINE_PRIM_PROC(eq_hash);
 DEFINE_PRIM_PROC(equal_hash);

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -630,20 +630,73 @@ int test_hashtable() {
                    "(hashtable-set! h 'l 12) "
                    "(hashtable-size h))",
                 "12");
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3)"
+                   "(hashtable-set! h 'a 4) "
+                   "(hashtable-set! h 'b 5) "
+                   "(hashtable-set! h 'c 6)"
+                   "(hashtable-size h))",
+                "3");
+
+    check_equal("(begin "
+                  "(define h (make-hashtable)) "
+                  "(hashtable-set! h 'a 1) "
+                  "(hashtable-size h))",
+                "1");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-size h))",
+                "2");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3)"
+                   "(hashtable-size h))",
+                "3");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3) "
+                   "(hashtable-set! h 'd 4) "
+                   "(hashtable-set! h 'e 5) "
+                   "(hashtable-set! h 'f 6) "
+                   "(hashtable-set! h 'g 7) "
+                   "(hashtable-set! h 'h 8) "
+                   "(hashtable-set! h 'i 9) "
+                   "(hashtable-set! h 'j 10) "
+                   "(hashtable-set! h 'k 11) "
+                   "(hashtable-set! h 'l 12) "
+                   "(hashtable-size h))",
+                "12");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3)"
+                   "(hashtable-set! h 'a 4) "
+                   "(hashtable-set! h 'b 5) "
+                   "(hashtable-set! h 'c 6)"
+                   "(hashtable-size h))",
+                "3");
 
     check_equal("(begin "
                    "(define h (make-eq-hashtable)) "
                    "(hashtable-set! h 'a 1) "
                    "(hashtable-ref h 'a))",
                 "1");
-    
     check_equal("(begin "
                    "(define h (make-eq-hashtable)) "
                    "(hashtable-set! h 'a 1) "
                    "(hashtable-set! h 'b 2) "
                    "(hashtable-ref h 'b))",
                 "2");
-    
     check_equal("(begin "
                    "(define h (make-eq-hashtable)) "
                    "(hashtable-set! h 'a 1) "
@@ -651,6 +704,49 @@ int test_hashtable() {
                    "(hashtable-set! h 'c 3) "
                    "(hashtable-ref h 'c))",
                 "3");
+
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h '() 1) "
+                   "(hashtable-set! h '() 2) "
+                   "(hashtable-ref h '()))",
+                "2");
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h #() 1) "
+                   "(hashtable-set! h #() 2) "
+                   "(hashtable-ref h #()))",
+                "2");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h '(1) 1) "
+                   "(hashtable-set! h '(1) 2) "
+                   "(hashtable-ref h '(1)))",
+                "2");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h #(1) 1) "
+                   "(hashtable-set! h #(1) 2) "
+                   "(hashtable-ref h #(1)))",
+                "2");
+
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-contains? h 'a))",
+                "#t");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-contains? h 'b))",
+                "#f");
+
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-delete! h 'a) "
+                   "(hashtable-contains? h 'a))",
+                "#f");
 
     return passed;
 }

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -143,6 +143,9 @@ int test_type_predicates() {
     check_true ("(procedure? (lambda () 1))");
     check_false("(procedure? 1)");
 
+    check_true("(hashtable? (make-eq-hashtable))");
+    check_false("(hashtable? 1)");
+
     return passed;
 }
 

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -759,6 +759,13 @@ int test_hashtable() {
                    "(hashtable-size h))",
                 "10000");
 
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-update! h 'a (lambda (x) (* 2 x))) "
+                   "(hashtable-ref h 'a))",
+                "2");
+
     return passed;
 }
 

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -785,6 +785,20 @@ int test_hashtable() {
                    "(hashtable-ref h 'a))",
                 "4");
 
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-ref (hashtable-copy h) 'a))",
+                "1");
+
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3) "
+                   "(hashtable-ref (hashtable-copy h) 'b))",
+                "2");
+
     return passed;
 }
 

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -593,6 +593,48 @@ int test_let() {
     return passed;
 }
 
+int test_hashtable() {
+    passed = 1;
+
+    check_equal("(begin "
+                  "(define h (make-eq-hashtable)) "
+                  "(hashtable-set! h 'a 1) "
+                  "(hashtable-size h))",
+                "1");
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-size h))",
+                "2");
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3)"
+                   "(hashtable-size h))",
+                "3");
+
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3) "
+                   "(hashtable-set! h 'd 4) "
+                   "(hashtable-set! h 'e 5) "
+                   "(hashtable-set! h 'f 6) "
+                   "(hashtable-set! h 'g 7) "
+                   "(hashtable-set! h 'h 8) "
+                   "(hashtable-set! h 'i 9) "
+                   "(hashtable-set! h 'j 10) "
+                   "(hashtable-set! h 'k 11) "
+                   "(hashtable-set! h 'l 12) "
+                   "(hashtable-size h))",
+                "12");
+
+    return passed;
+}
+
 void run_tests() {
     log_test("simple eval", test_simple_eval);
     log_test("syntax", test_syntax);
@@ -612,6 +654,7 @@ void run_tests() {
     log_test("list", test_list);
     log_test("vector", test_vector);
     log_test("integer", test_integer);
+    log_test("hashtable", test_hashtable);
 }
 
 int main(int argc, char **argv) {

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -748,6 +748,17 @@ int test_hashtable() {
                    "(hashtable-contains? h 'a))",
                 "#f");
 
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(let loop ([i 0]) "
+                     "(if (= i 10000) "
+                         "(void) "
+                         "(begin "
+                           "(hashtable-set! h i (+ i 1)) "
+                           "(loop (+ i 1))))) "
+                   "(hashtable-size h))",
+                "10000");
+
     return passed;
 }
 

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -614,7 +614,6 @@ int test_hashtable() {
                    "(hashtable-set! h 'c 3)"
                    "(hashtable-size h))",
                 "3");
-
     check_equal("(begin "
                    "(define h (make-eq-hashtable)) "
                    "(hashtable-set! h 'a 1) "
@@ -631,6 +630,27 @@ int test_hashtable() {
                    "(hashtable-set! h 'l 12) "
                    "(hashtable-size h))",
                 "12");
+
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-ref h 'a))",
+                "1");
+    
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-ref h 'b))",
+                "2");
+    
+    check_equal("(begin "
+                   "(define h (make-eq-hashtable)) "
+                   "(hashtable-set! h 'a 1) "
+                   "(hashtable-set! h 'b 2) "
+                   "(hashtable-set! h 'c 3) "
+                   "(hashtable-ref h 'c))",
+                "3");
 
     return passed;
 }

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -761,10 +761,29 @@ int test_hashtable() {
 
     check_equal("(begin "
                    "(define h (make-hashtable)) "
+                   "(hashtable-ref h 'a 0))",
+                "0");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-ref h 'a (lambda () 0)))",
+                "0");
+
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
                    "(hashtable-set! h 'a 1) "
                    "(hashtable-update! h 'a (lambda (x) (* 2 x))) "
                    "(hashtable-ref h 'a))",
                 "2");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-update! h 'a (lambda (x) (* 2 x)) 2) "
+                   "(hashtable-ref h 'a))",
+                "4");
+    check_equal("(begin "
+                   "(define h (make-hashtable)) "
+                   "(hashtable-update! h 'a (lambda (x) (* 2 x)) (lambda () 2)) "
+                   "(hashtable-ref h 'a))",
+                "4");
 
     return passed;
 }


### PR DESCRIPTION
This PR adds support for hash-tables in the bootstrap interpreter:
- `make-eq-hashtable`, `make-hashtable`
- `hashtable?`, `hashtable-contains?`
- `hashtable-size`, `hashtable-keys`
- `hashtable-set!`, `hashtable-update!`, `hashtable-clear!`
- `hashtable-ref`
- `hashtable-copy`