### PR TITLE
Cleanup

### DIFF
--- a/src/boot/Makefile
+++ b/src/boot/Makefile
@@ -18,7 +18,7 @@ DEPS 		:= $(OBJS:.o=.d)
 TESTS		:= $(shell find $(TEST_DIR) -name "*.c")
 TEST_EXES	:= $(TESTS:%.c=$(BUILD_DIR)/%)
 
-CFLAGS		:= -Wall -std=c11 -O2 -g
+CFLAGS		:= -Wall -std=c11 -O0 -g
 DEPFLAGS 	:= -MMD -MP
 LDFLAGS 	:= -L$(GC_DIR) -lgc
 

--- a/src/boot/Makefile
+++ b/src/boot/Makefile
@@ -18,7 +18,7 @@ DEPS 		:= $(OBJS:.o=.d)
 TESTS		:= $(shell find $(TEST_DIR) -name "*.c")
 TEST_EXES	:= $(TESTS:%.c=$(BUILD_DIR)/%)
 
-CFLAGS		:= -Wall -std=c11 -O0 -g
+CFLAGS		:= -Wall -std=c11 -O2 -g
 DEPFLAGS 	:= -MMD -MP
 LDFLAGS 	:= -L$(GC_DIR) -lgc
 

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -9,19 +9,19 @@
 //  Primitives
 //
 
-static minim_object *boot_expander_proc(minim_object *args) {
+static minim_object *boot_expander_proc(int argc, minim_object **args) {
     // (-> boolean)
     // (-> boolean void)
     minim_object *val;
     minim_thread *th;
 
     th = current_thread();
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         // getter
         return boot_expander(th);
     } else {
         // setter
-        val = minim_car(args);
+        val = args[0];
         if (!minim_is_bool(val))
             bad_type_exn("boot-expander?", "boolean?", val);
         boot_expander(th) = val;

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -286,8 +286,16 @@ void minim_boot_init() {
     GC_register_root(minim_eof);
     GC_register_root(minim_void);
     GC_register_root(minim_values);
-
     GC_register_root(globals);
+
+    // Interpreter runtime
+
+    irt_call_args = GC_alloc(CALL_ARGS_DEFAULT * sizeof(minim_object*));
+    irt_saved_args = GC_alloc(SAVED_ARGS_DEFAULT * sizeof(minim_object*));
+    irt_call_args_count = 0;
+    irt_saved_args_count = 0;
+    irt_call_args_size = CALL_ARGS_DEFAULT;
+    irt_saved_args_size = SAVED_ARGS_DEFAULT;
 
     GC_resume();
 }

--- a/src/boot/c/char.c
+++ b/src/boot/c/char.c
@@ -15,22 +15,22 @@ minim_object *make_char(int c) {
 //  Primitives
 //
 
-minim_object *is_char_proc(minim_object *args) {
+minim_object *is_char_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_char(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_char(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *char_to_integer_proc(minim_object *args) {
+minim_object *char_to_integer_proc(int argc, minim_object **args) {
     // (-> char integer)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_char(o))
         bad_type_exn("char->integer", "char?", o);
     return make_fixnum(minim_char(o));
 }
 
-minim_object *integer_to_char_proc(minim_object *args) {
+minim_object *integer_to_char_proc(int argc, minim_object **args) {
     // (-> integer char)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_fixnum(o))
         bad_type_exn("integer->char", "integer?", o);
     return make_char(minim_fixnum(minim_car(args)));

--- a/src/boot/c/char.c
+++ b/src/boot/c/char.c
@@ -33,5 +33,5 @@ minim_object *integer_to_char_proc(int argc, minim_object **args) {
     minim_object *o = args[0];
     if (!minim_is_fixnum(o))
         bad_type_exn("integer->char", "integer?", o);
-    return make_char(minim_fixnum(minim_car(args)));
+    return make_char(minim_fixnum(args[0]));
 }

--- a/src/boot/c/env.c
+++ b/src/boot/c/env.c
@@ -63,7 +63,7 @@ void env_define_var_no_check(minim_object *env, minim_object *var, minim_object 
         fprintf(stderr, "env_define_var_no_check(): not an environment frame: ");
         write_object(stderr, frame);
         fprintf(stderr, "\n");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -98,7 +98,7 @@ minim_object *env_define_var(minim_object *env, minim_object *var, minim_object 
         fprintf(stderr, "env_define_var(): not an environment frame: ");
         write_object(stderr, frame);
         fprintf(stderr, "\n");
-        exit(1);
+        minim_shutdown(1);
     }
 
     // else just add
@@ -137,14 +137,14 @@ minim_object *env_set_var(minim_object *env, minim_object *var, minim_object *va
             fprintf(stderr, "env_lookup_var(): not an environment frame: ");
             write_object(stderr, frame);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         }
 
         env = minim_env_prev(env);
     }
 
     fprintf(stderr, "unbound variable: %s\n", minim_symbol(var));
-    exit(1);
+    minim_shutdown(1);
 }
 
 int env_var_is_defined(minim_object *env, minim_object *var, int recursive) {
@@ -172,7 +172,7 @@ int env_var_is_defined(minim_object *env, minim_object *var, int recursive) {
             fprintf(stderr, "env_var_is_defined(): not an environment frame: ");
             write_object(stderr, frame);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         }
 
         if (!recursive)
@@ -209,14 +209,14 @@ minim_object *env_lookup_var(minim_object *env, minim_object *var) {
             fprintf(stderr, "env_lookup_var(): not an environment frame: ");
             write_object(stderr, frame);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         }
 
         env = minim_env_prev(env);
     }
 
     fprintf(stderr, "unbound variable: %s\n", minim_symbol(var));
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *extend_env(minim_object *vars,
@@ -319,5 +319,5 @@ minim_object *environment_set_variable_value_proc(minim_object *args) {
 
 minim_object *current_environment_proc(minim_object *args) {
     fprintf(stderr, "current-environment: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }

--- a/src/boot/c/env.c
+++ b/src/boot/c/env.c
@@ -19,6 +19,13 @@ minim_object *empty_env;
 //    - otherwise we allocate a hashtable
 //
 
+static void not_environment_exn(const char *name, minim_object *frame) {
+    fprintf(stderr, "%s: not an environment frame: ", name);
+    write_object(stderr, frame);
+    fprintf(stderr, "\n");
+    minim_shutdown(1);
+}
+
 minim_object *make_environment(minim_object *prev) {
     minim_env *env = GC_alloc(sizeof(minim_env));
     env->type = MINIM_ENVIRONMENT_TYPE;
@@ -60,10 +67,7 @@ void env_define_var_no_check(minim_object *env, minim_object *var, minim_object 
         // large namespace
         hashtable_set(frame, var, val);
     } else {
-        fprintf(stderr, "env_define_var_no_check(): not an environment frame: ");
-        write_object(stderr, frame);
-        fprintf(stderr, "\n");
-        minim_shutdown(1);
+        not_environment_exn("env_define_var_no_check()", frame);
     }
 }
 
@@ -95,10 +99,7 @@ minim_object *env_define_var(minim_object *env, minim_object *var, minim_object 
             return old;
         }
     } else {
-        fprintf(stderr, "env_define_var(): not an environment frame: ");
-        write_object(stderr, frame);
-        fprintf(stderr, "\n");
-        minim_shutdown(1);
+        not_environment_exn("env_define_var()", frame);
     }
 
     // else just add
@@ -134,10 +135,7 @@ minim_object *env_set_var(minim_object *env, minim_object *var, minim_object *va
                 return old;
             }
         } else {
-            fprintf(stderr, "env_lookup_var(): not an environment frame: ");
-            write_object(stderr, frame);
-            fprintf(stderr, "\n");
-            minim_shutdown(1);
+            not_environment_exn("env_set_var()", frame);
         }
 
         env = minim_env_prev(env);
@@ -169,10 +167,7 @@ int env_var_is_defined(minim_object *env, minim_object *var, int recursive) {
             if (!minim_is_null(bind))
                 return 1;
         } else {
-            fprintf(stderr, "env_var_is_defined(): not an environment frame: ");
-            write_object(stderr, frame);
-            fprintf(stderr, "\n");
-            minim_shutdown(1);
+            not_environment_exn("env_var_is_defined()", frame);
         }
 
         if (!recursive)
@@ -206,10 +201,7 @@ minim_object *env_lookup_var(minim_object *env, minim_object *var) {
             if (!minim_is_null(bind))
                 return minim_cdr(bind);
         } else {
-            fprintf(stderr, "env_lookup_var(): not an environment frame: ");
-            write_object(stderr, frame);
-            fprintf(stderr, "\n");
-            minim_shutdown(1);
+            not_environment_exn("env_lookup_var()", frame);
         }
 
         env = minim_env_prev(env);

--- a/src/boot/c/env.c
+++ b/src/boot/c/env.c
@@ -283,7 +283,9 @@ minim_object *environment_variable_value_proc(minim_object *args) {
             exn = minim_car(minim_cddr(args));
             if (!minim_is_proc(exn))
                 bad_type_exn("environment-variable-value", "procedure?", exn);
-            return call_with_args(exn, minim_null, env);
+
+            assert_no_call_args();
+            return call_with_args(exn, env);
         }
     }
 

--- a/src/boot/c/env.c
+++ b/src/boot/c/env.c
@@ -236,37 +236,37 @@ minim_object *setup_env() {
 //  Primitives
 //
 
-minim_object *interaction_environment_proc(minim_object *args) {
+minim_object *interaction_environment_proc(int argc, minim_object **args) {
     // (-> environment)
     return global_env(current_thread());
 }
 
-minim_object *empty_environment_proc(minim_object *args) {
+minim_object *empty_environment_proc(int argc, minim_object **args) {
     // (-> environment)
     return setup_env();
 }
 
-minim_object *environment_proc(minim_object *args) {
+minim_object *environment_proc(int argc, minim_object **args) {
     // (-> environment)
     return make_env();
 }
 
-minim_object *extend_environment_proc(minim_object *args) {
+minim_object *extend_environment_proc(int argc, minim_object **args) {
     // (-> environment environment)
-    if (!minim_is_env(minim_car(args)))
-        bad_type_exn("extend-environment", "environment?", minim_car(args));
-    return make_environment(minim_car(args));
+    if (!minim_is_env(args[0]))
+        bad_type_exn("extend-environment", "environment?", args[0]);
+    return make_environment(args[0]);
 }
 
-minim_object *environment_variable_value_proc(minim_object *args) {
+minim_object *environment_variable_value_proc(int argc, minim_object **args) {
     // (-> environment symbol -> any)
     minim_object *env, *name, *exn;
 
-    env = minim_car(args);
+    env = args[0];
     if (!minim_is_env(env))
         bad_type_exn("environment-variable-value", "environment?", env);
 
-    name = minim_cadr(args);
+    name = args[1];
     if (!minim_is_symbol(name)) {
         bad_type_exn("environment-variable-value", "symbol?", name);
     } else if (env_var_is_defined(env, name, 0)) {
@@ -274,13 +274,13 @@ minim_object *environment_variable_value_proc(minim_object *args) {
         return env_lookup_var(env, name);
     } else {
         // variable not found
-        if (minim_is_null(minim_cddr(args))) {
+        if (argc == 2) {
             // default exception
             fprintf(stderr, "environment-variable-value: variable not bound");
             fprintf(stderr, " name: %s", minim_symbol(name));
         } else {
             // custom exception
-            exn = minim_car(minim_cddr(args));
+            exn = args[2];
             if (!minim_is_proc(exn))
                 bad_type_exn("environment-variable-value", "procedure?", exn);
 
@@ -293,25 +293,24 @@ minim_object *environment_variable_value_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *environment_set_variable_value_proc(minim_object *args) {
+minim_object *environment_set_variable_value_proc(int argc, minim_object **args) {
     // (-> environment symbol any void)
     minim_object *env, *name, *val;
 
-    env = minim_car(args);
+    env = args[0];
     if (!minim_is_env(env))
         bad_type_exn("environment-set-variable-value!", "environment?", env);
 
-    name = minim_cadr(args);
-    val = minim_car(minim_cddr(args));
-
+    name = args[1];
     if (!minim_is_symbol(name))
         bad_type_exn("environment-set-variable-value!", "symbol?", name);
 
+    val = args[2];
     env_define_var(env, name, val);
     return minim_void;
 }
 
-minim_object *current_environment_proc(minim_object *args) {
+minim_object *current_environment_proc(int argc, minim_object **args) {
     fprintf(stderr, "current-environment: should not be called directly");
     minim_shutdown(1);
 }

--- a/src/boot/c/eval.c
+++ b/src/boot/c/eval.c
@@ -46,7 +46,6 @@ void push_saved_arg(minim_object *arg) {
 }
 
 void clear_call_args() {
-    irt_call_args[0] = NULL;
     irt_call_args_count = 0;
 }
 
@@ -145,7 +144,7 @@ static int check_proc_arity(proc_arity *arity, int argc, const char *name) {
     min_arity = proc_arity_min(arity);
     max_arity = proc_arity_max(arity);
 
-    if (argc >= max_arity)
+    if (argc > max_arity)
         arity_mismatch_exn(name, arity, argc);
 
     if (argc < min_arity)
@@ -613,7 +612,7 @@ application:
 
         // special case for `for-each`
         if (minim_prim_proc(proc) == for_each_proc) {
-            return for_each(args[0], args[1], env);
+            return for_each(args[0], &args[1], env);
         }
 
         // special case for `map`
@@ -647,6 +646,7 @@ application:
         args = irt_call_args;
 
         // process args
+        i = 0;
         vars = minim_closure_args(proc);
         while (minim_is_pair(vars)) {
             env_define_var_no_check(env, minim_car(vars), args[i]);
@@ -994,6 +994,7 @@ application:
             args = irt_call_args;
 
             // process args
+            i = 0;
             vars = minim_closure_args(proc);
             while (minim_is_pair(vars)) {
                 env_define_var_no_check(env, minim_car(vars), args[i]);

--- a/src/boot/c/eval.c
+++ b/src/boot/c/eval.c
@@ -612,22 +612,22 @@ application:
 
         // special case for `for-each`
         if (minim_prim_proc(proc) == for_each_proc) {
-            return for_each(args[0], &args[1], env);
+            return for_each(args[0], argc - 1, &args[1], env);
         }
 
         // special case for `map`
         if (minim_prim_proc(proc) == map_proc) {
-            return map_list(args[0], args[1], env);
+            return map_list(args[0], argc - 1, &args[1], env);
         }
 
         // special case for `andmap`
         if (minim_prim_proc(proc) == andmap_proc) {
-            return andmap(args[0], args[1], env);
+            return andmap(args[0], argc - 1, &args[1], env);
         }
 
         // special case for `ormap`
         if (minim_prim_proc(proc) == ormap_proc) {
-            return ormap(args[0], args[1], env);
+            return ormap(args[0], argc - 1, &args[1], env);
         }
 
         // special case for `call-with-values`
@@ -960,22 +960,22 @@ application:
 
             // special case for `for-each`
             if (minim_prim_proc(proc) == for_each_proc) {
-                return for_each(args[0], args[1], env);
+                return for_each(args[0], argc - 1, &args[1], env);
             }
 
             // special case for `map`
             if (minim_prim_proc(proc) == map_proc) {
-                return map_list(args[0], args[1], env);
+                return map_list(args[0], argc - 1, &args[1], env);
             }
 
             // special case for `andmap`
             if (minim_prim_proc(proc) == andmap_proc) {
-                return andmap(args[0], args[1], env);
+                return andmap(args[0], argc - 1, &args[1], env);
             }
 
             // special case for `ormap`
             if (minim_prim_proc(proc) == ormap_proc) {
-                return ormap(args[0], args[1], env);
+                return ormap(args[0], argc - 1, &args[1], env);
             }
 
             // special case for `call-with-values`

--- a/src/boot/c/eval.c
+++ b/src/boot/c/eval.c
@@ -20,7 +20,7 @@ void bad_syntax_exn(minim_object *expr) {
     fprintf(stderr, " at: ");
     write_object2(stderr, expr, 1, 0);
     fputc('\n', stderr);
-    exit(1);
+    minim_shutdown(1);
 }
 
 void bad_type_exn(const char *name, const char *type, minim_object *x) {
@@ -29,7 +29,7 @@ void bad_type_exn(const char *name, const char *type, minim_object *x) {
     fprintf(stderr, " received: ");
     write_object(stderr, x);
     fputc('\n', stderr);
-    exit(1);
+    minim_shutdown(1);
 }
 
 static void arity_mismatch_exn(const char *name, proc_arity *arity, short actual) {
@@ -70,7 +70,7 @@ static void arity_mismatch_exn(const char *name, proc_arity *arity, short actual
                         proc_arity_min(arity), proc_arity_max(arity), actual);
     }
 
-    exit(1);
+    minim_shutdown(1);
 }
 
 static int check_proc_arity(proc_arity *arity, minim_object *args, const char *name) {
@@ -226,7 +226,7 @@ static void check_cond(minim_object *expr) {
             fprintf(stderr, " at: ");
             write_object2(stderr, expr, 1, 0);
             fputc('\n', stderr);
-            exit(1);
+            minim_shutdown(1);
         }
 
         rest = minim_cdr(rest);
@@ -333,7 +333,7 @@ static void check_lambda(minim_object *expr, short *min_arity, short *max_arity)
             fprintf(stderr, "expected a identifier for an argument:\n ");
             write_object(stderr, expr);
             fputc('\n', stderr);
-            exit(1);
+            minim_shutdown(1);
         }
 
         args = minim_cdr(args);
@@ -350,7 +350,7 @@ static void check_lambda(minim_object *expr, short *min_arity, short *max_arity)
         fprintf(stderr, "expected an identifier for the rest argument:\n ");
         write_object(stderr, expr);
         fputc('\n', stderr);
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -495,7 +495,7 @@ static minim_object *eval_exprs(minim_object *exprs, minim_object *env) {
             if (values_buffer_count(th) != 1) {
                 fprintf(stderr, "result arity mismatch\n");
                 fprintf(stderr, "  expected: 1, received: %d\n", values_buffer_count(th));
-                exit(1);
+                minim_shutdown(1);
             } else {
                 result = values_buffer_ref(th, 0);
             }
@@ -626,7 +626,7 @@ application:
         fprintf(stderr, " received:");
         write_object(stderr, proc);
         fprintf(stderr, "\n");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -649,7 +649,7 @@ loop:
         fprintf(stderr, "missing procedure expression\n");
         fprintf(stderr, "  in: ");
         write_object2(stderr, expr, 0, 0);
-        exit(1);
+        minim_shutdown(1);
     } else if (minim_is_pair(expr)) {
         minim_object *proc, *head, *args, *result, *it, *bindings, *bind, *env2;
         minim_thread *th;
@@ -670,7 +670,7 @@ loop:
                         fprintf(stderr, "result arity mismatch\n");
                         fprintf(stderr, "  expected: %ld, received: %d\n",
                                         var_count, values_buffer_count(th));
-                        exit(1);
+                        minim_shutdown(1);
                     }
 
                     idx = 0;
@@ -683,7 +683,7 @@ loop:
                     if (var_count != 1) {
                         fprintf(stderr, "result arity mismatch\n");
                         fprintf(stderr, "  expected: %ld, received: 1\n", var_count);
-                        exit(1);
+                        minim_shutdown(1);
                     }
                     
                     SET_NAME_IF_CLOSURE(minim_car(minim_cadr(expr)), result);
@@ -707,7 +707,7 @@ loop:
                             fprintf(stderr, "result arity mismatch\n");
                             fprintf(stderr, "  expected: %ld, received: %d\n",
                                             var_count, values_buffer_count(th));
-                            exit(1);
+                            minim_shutdown(1);
                         }
 
                         idx = 0;
@@ -720,7 +720,7 @@ loop:
                         if (var_count != 1) {
                             fprintf(stderr, "result arity mismatch\n");
                             fprintf(stderr, "  expected: %ld, received: 1\n", var_count);
-                            exit(1);
+                            minim_shutdown(1);
                         }
                         
                         SET_NAME_IF_CLOSURE(minim_caar(bind), result);
@@ -749,7 +749,7 @@ loop:
                             fprintf(stderr, "result arity mismatch\n");
                             fprintf(stderr, "  expected: %ld, received: %d\n",
                                             var_count, values_buffer_count(th));
-                            exit(1);
+                            minim_shutdown(1);
                         }
 
                         idx = 0;
@@ -760,7 +760,7 @@ loop:
                         if (var_count != 1) {
                             fprintf(stderr, "result arity mismatch\n");
                             fprintf(stderr, "  expected: %ld, received: 1\n", var_count);
-                            exit(1);
+                            minim_shutdown(1);
                         }
                         
                         to_bind = make_pair(make_pair(minim_caar(bind), result), to_bind);
@@ -853,7 +853,7 @@ loop:
                         if (minim_caar(expr) == else_symbol) {
                             if (!minim_is_null(minim_cdr(expr))) {
                                 fprintf(stderr, "else clause must be last");
-                                exit(1);
+                                minim_shutdown(1);
                             }
                             expr = make_pair(begin_symbol, minim_cdar(expr));
                             goto loop;
@@ -985,15 +985,15 @@ application:
             fprintf(stderr, " received:");
             write_object(stderr, proc);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         }
     } else {
         fprintf(stderr, "bad syntax\n");
         write_object(stderr, expr);
         fprintf(stderr, "\n");
-        exit(1);
+        minim_shutdown(1);
     }
 
     fprintf(stderr, "unreachable\n");
-    exit(1);
+    minim_shutdown(1);
 }

--- a/src/boot/c/eval.c
+++ b/src/boot/c/eval.c
@@ -36,13 +36,13 @@ void push_call_arg(minim_object *arg) {
     if (irt_call_args_count >= irt_call_args_size)
         resize_call_args(irt_call_args_count + 1);
     irt_call_args[irt_call_args_count++] = arg;
+    irt_call_args[irt_call_args_count] = NULL;
 }
 
 void push_saved_arg(minim_object *arg) {
     if (irt_saved_args_count >= irt_saved_args_size)
         resize_saved_args(irt_saved_args_count + 2);
     irt_saved_args[irt_saved_args_count++] = arg;
-    irt_saved_args[irt_saved_args_count] = NULL;
 }
 
 void clear_call_args() {

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -396,7 +396,7 @@ minim_object *hashtable_update_proc(int argc, minim_object **args) {
 
     b = hashtable_find(ht, k);
     if (minim_is_null(b)) {
-        if (minim_is_null(minim_cdr(minim_cddr(args)))) {
+        if (argc == 3) {
             // no failure result provided
             key_not_found_exn("hashtable-update!", k);
         } else {
@@ -439,7 +439,7 @@ minim_object *hashtable_ref_proc(int argc, minim_object **args) {
     k = args[1];
     b = hashtable_find(ht, k);
     if (minim_is_null(b)) {
-        if (minim_is_null(minim_cddr(args))) {
+        if (argc == 2) {
             // no failure result provided
             key_not_found_exn("hashtable-ref", k);
             write_object(stderr, k);

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -168,7 +168,7 @@ static uint64_t hash_key(minim_object *ht, minim_object *k) {
             fprintf(stderr, "hash function associated with hash table ");
             write_object(stderr, ht);
             fprintf(stderr, " did not return a fixnum");
-            exit(1);
+            minim_shutdown(1);
         }
 
         return minim_fixnum(i);
@@ -368,7 +368,7 @@ minim_object *hashtable_delete_proc(minim_object *args) {
         fprintf(stderr, "hashtable-delete!: could not find key ");
         write_object(stderr, k);
         fprintf(stderr, "\n");
-        exit(1);
+        minim_shutdown(1);
     }
 
     return minim_void;
@@ -395,7 +395,7 @@ minim_object *hashtable_update_proc(minim_object *args) {
             fprintf(stderr, "hashtable-update!: could not find key ");
             write_object(stderr, k);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         } else {
             // user-provided failure
             minim_object *fail, *v;
@@ -436,7 +436,7 @@ minim_object *hashtable_ref_proc(minim_object *args) {
             fprintf(stderr, "hashtable-ref: could not find key ");
             write_object(stderr, k);
             fprintf(stderr, "\n");
-            exit(1);
+            minim_shutdown(1);
         } else {
             // user-provided failure
             minim_object *fail, *env;

--- a/src/boot/c/hashtable.c
+++ b/src/boot/c/hashtable.c
@@ -312,85 +312,85 @@ static void key_not_found_exn(const char *name, minim_object *k) {
 //  Primitives
 //
 
-minim_object *is_hashtable_proc(minim_object *args) {
+minim_object *is_hashtable_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return (minim_is_hashtable(minim_car(args)) ? minim_true : minim_false);
+    return (minim_is_hashtable(args[0]) ? minim_true : minim_false);
 }
 
-minim_object *make_eq_hashtable_proc(minim_object *args) {
+minim_object *make_eq_hashtable_proc(int argc, minim_object **args) {
     // (-> hashtable)
     return make_hashtable(make_prim_proc(eq_hash_proc, "eq-hash", 1, 1),
                           make_prim_proc(eq_proc, "eq?", 2, 2));
 }
 
-minim_object *make_hashtable_proc(minim_object *args) {
+minim_object *make_hashtable_proc(int argc, minim_object **args) {
     // (-> hashtable)
     return make_hashtable(make_prim_proc(equal_hash_proc, "equal-hash", 1, 1),
                           make_prim_proc(equal_proc, "equal?", 2, 2));
 }
 
-minim_object *hashtable_size_proc(minim_object *args) {
+minim_object *hashtable_size_proc(int argc, minim_object **args) {
     // (-> hashtable any any void)
     minim_object *ht;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-set!", "hashtable?", ht);
     return make_fixnum(minim_hashtable_size(ht));
 }
 
-minim_object *hashtable_contains_proc(minim_object *args) {
+minim_object *hashtable_contains_proc(int argc, minim_object **args) {
     // (-> hashtable any boolean)
     minim_object *ht, *k;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-contains?", "hashtable?", ht);
 
-    k = minim_cadr(args);
+    k = args[1];
     return (minim_is_null(hashtable_find(ht, k)) ? minim_false : minim_true);
 }
 
-minim_object *hashtable_set_proc(minim_object *args) {
+minim_object *hashtable_set_proc(int argc, minim_object **args) {
     // (-> hashtable any any void)
     minim_object *ht, *k, *v;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-set!", "hashtable?", ht);
 
-    k = minim_cadr(args);
-    v = minim_car(minim_cddr(args));
+    k = args[1];
+    v = args[2];
     hashtable_set(ht, k, v);
     return minim_void;
 }
 
-minim_object *hashtable_delete_proc(minim_object *args) {
+minim_object *hashtable_delete_proc(int argc, minim_object **args) {
     // (-> hashtable any void)
     minim_object *ht, *k;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-delete!", "hashtable?", ht);
 
-    k = minim_cadr(args);
+    k = args[1];
     if (!hashtable_delete(ht, k))
         key_not_found_exn("hashtable-delete!", k);
 
     return minim_void;
 }
 
-minim_object *hashtable_update_proc(minim_object *args) {
+minim_object *hashtable_update_proc(int argc, minim_object **args) {
     // (-> hashtable any (-> any any) void)
     // (-> hashtable any (-> any any) any void)
     minim_object *ht, *k, *proc, *b, *env;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-update!", "hashtable?", ht);
 
-    k = minim_cadr(args);
-    proc = minim_car(minim_cddr(args));
+    k = args[1];
+    proc = args[2];
     if (!minim_is_proc(proc))
         bad_type_exn("hashtable-update!", "procedure?", proc);
 
@@ -403,7 +403,7 @@ minim_object *hashtable_update_proc(minim_object *args) {
             // user-provided failure
             minim_object *fail, *v;
 
-            fail = minim_cadr(minim_cddr(args));
+            fail = args[3];
             env = global_env(current_thread());     // TODO: this seems problematic
             if (!minim_is_proc(fail)) {
                 b = fail;
@@ -427,16 +427,16 @@ minim_object *hashtable_update_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *hashtable_ref_proc(minim_object *args) {
+minim_object *hashtable_ref_proc(int argc, minim_object **args) {
     // (-> hashtable any any)
     // (-> hashtable any any any)
     minim_object *ht, *k, *b;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-ref", "hashtable?", ht);
 
-    k = minim_cadr(args);
+    k = args[1];
     b = hashtable_find(ht, k);
     if (minim_is_null(b)) {
         if (minim_is_null(minim_cddr(args))) {
@@ -449,7 +449,7 @@ minim_object *hashtable_ref_proc(minim_object *args) {
             // user-provided failure
             minim_object *fail, *env;
 
-            fail = minim_car(minim_cddr(args));
+            fail = args[2];
             if (!minim_is_proc(fail))
                 return fail;
             
@@ -462,41 +462,41 @@ minim_object *hashtable_ref_proc(minim_object *args) {
     return minim_cdr(b);
 }
 
-minim_object *hashtable_keys_proc(minim_object *args) {
+minim_object *hashtable_keys_proc(int argc, minim_object **args) {
     // (-> hashtable (listof any))
     minim_object *ht;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-keys", "hashtable?", ht);
     return hashtable_keys(ht);
 }
 
-minim_object *hashtable_copy_proc(minim_object *args) {
+minim_object *hashtable_copy_proc(int argc, minim_object **args) {
     // (-> hashtable void)
     minim_object *ht;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-copy", "hashtable?", ht);
     return copy_hashtable(ht);
 }
 
-minim_object *hashtable_clear_proc(minim_object *args) {
+minim_object *hashtable_clear_proc(int argc, minim_object **args) {
     // (-> hashtable void)
     minim_object *ht;
 
-    ht = minim_car(args);
+    ht = args[0];
     if (!minim_is_hashtable(ht))
         bad_type_exn("hashtable-clear!", "hashtable?", ht);
     hashtable_clear(ht);
     return minim_void;
 }
 
-minim_object *eq_hash_proc(minim_object *args) {
-    return make_fixnum(eq_hash(minim_car(args)));
+minim_object *eq_hash_proc(int argc, minim_object **args) {
+    return make_fixnum(eq_hash(args[0]));
 }
 
-minim_object *equal_hash_proc(minim_object *args) {
-    return make_fixnum(equal_hash(minim_car(args)));
+minim_object *equal_hash_proc(int argc, minim_object **args) {
+    return make_fixnum(equal_hash(args[0]));
 }

--- a/src/boot/c/io.c
+++ b/src/boot/c/io.c
@@ -11,7 +11,7 @@
 static void assert_not_eof(char c) {
     if (c == EOF) {
         fprintf(stderr, "unexpected end of input\n");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -20,7 +20,7 @@ static void assert_matching_paren(char open, char closed) {
         !(open == '[' && closed == ']') &&
         !(open == '{' && closed == '}')) {
         fprintf(stderr, "parenthesis mismatch: %c closed off %c\n", closed, open);
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -45,7 +45,7 @@ static int peek_char(FILE *in) {
 static void peek_expected_delimeter(FILE *in) {
     if (!is_delimeter(peek_char(in))) {
         fprintf(stderr, "expected a delimeter\n");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -56,7 +56,7 @@ static void read_expected_string(FILE *in, const char *s) {
         c = getc(in);
         if (c != *s) {
             fprintf(stderr, "unexpected character: '%c'\n", c);
-            exit(1);
+            minim_shutdown(1);
         }
         ++s;
     }
@@ -157,7 +157,7 @@ static minim_object *read_pair(FILE *in, char open_paren) {
         }
 
         fprintf(stderr, "missing ')' to terminate pair");
-        exit(1);        
+        minim_shutdown(1);        
     } else {
         // list
         ungetc(c, in);
@@ -257,7 +257,7 @@ loop:
             goto loop;
         default:
             fprintf(stderr, "unknown special constant");
-            exit(1);
+            minim_shutdown(1);
         }
     } else if (isdigit(c) || ((c == '-' || c == '+') && isdigit(peek_char(in)))) {
         // number
@@ -279,7 +279,7 @@ loop:
         // check for delimeter
         if (!is_delimeter(c)) {
             fprintf(stderr, "expected a delimeter\n");
-            exit(1);
+            minim_shutdown(1);
         }
 
         ungetc(c, in);
@@ -302,18 +302,18 @@ loop:
                     c = '\"';
                 } else {
                     fprintf(stderr, "unknown escape character: %c\n", c);
-                    exit(1);
+                    minim_shutdown(1);
                 }
             } else if (c == EOF) {
                 fprintf(stderr, "non-terminated string literal\n");
-                exit(1);
+                minim_shutdown(1);
             }
 
             if (i < SYMBOL_MAX_LEN - 1) {
                 buffer[i++] = c;
             } else {
                 fprintf(stderr, "string is too long, max allowed %d characters", SYMBOL_MAX_LEN);
-                exit(1);
+                minim_shutdown(1);
             }
         }
 
@@ -334,14 +334,14 @@ loop:
                 buffer[i++] = c;
             } else {
                 fprintf(stderr, "symbol is too long, max allowed %d characters", SYMBOL_MAX_LEN);
-                exit(1);
+                minim_shutdown(1);
             }
             c = getc(in);
         }
 
         if (!is_delimeter(c)) {
             fprintf(stderr, "expected a delimeter\n");
-            exit(1);
+            minim_shutdown(1);
         }
 
         ungetc(c, in);
@@ -351,11 +351,11 @@ loop:
         return NULL;
     } else {
         fprintf(stderr, "unexpected input: %c\n", c);
-        exit(1);
+        minim_shutdown(1);
     }
 
     fprintf(stderr, "unreachable");
-    exit(1);
+    minim_shutdown(1);
 }
 
 //
@@ -515,11 +515,11 @@ void write_object2(FILE *out, minim_object *o, int quote, int display) {
         break;
     case MINIM_VALUES_TYPE:
         fprintf(stderr, "cannot write multiple values\n");
-        exit(1);
+        minim_shutdown(1);
 
     default:
         fprintf(stderr, "cannot write unknown object\n");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -596,7 +596,7 @@ minim_object *open_input_port_proc(minim_object *args) {
     stream = fopen(minim_string(minim_car(args)), "r");
     if (stream == NULL) {
         fprintf(stderr, "could not open file \"%s\"\n", minim_string(minim_car(args)));
-        exit(1);
+        minim_shutdown(1);
     }
 
     port = make_input_port(stream);
@@ -615,7 +615,7 @@ minim_object *open_output_port_proc(minim_object *args) {
     stream = fopen(minim_string(minim_car(args)), "w");
     if (stream == NULL) {
         fprintf(stderr, "could not open file \"%s\"\n", minim_string(minim_car(args)));
-        exit(1);
+        minim_shutdown(1);
     }
 
     port = make_output_port(stream);

--- a/src/boot/c/io.c
+++ b/src/boot/c/io.c
@@ -565,37 +565,37 @@ minim_object *make_output_port(FILE *stream) {
 //  Primitives
 //
 
-minim_object *is_input_port_proc(minim_object *args) {
+minim_object *is_input_port_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_input_port(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_input_port(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *is_output_port_proc(minim_object *args) {
+minim_object *is_output_port_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_output_port(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_output_port(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *current_input_port_proc(minim_object *args) {
+minim_object *current_input_port_proc(int argc, minim_object **args) {
     // (-> input-port)
     return input_port(current_thread());
 }
 
-minim_object *current_output_port_proc(minim_object *args) {
+minim_object *current_output_port_proc(int argc, minim_object **args) {
     // (-> output-port)
     return output_port(current_thread());
 }
 
-minim_object *open_input_port_proc(minim_object *args) {
+minim_object *open_input_port_proc(int argc, minim_object **args) {
     // (-> string input-port)
     minim_object *port;
     FILE *stream;
 
-    if (!minim_is_string(minim_car(args)))
-        bad_type_exn("open-input-port", "string?", minim_car(args));
+    if (!minim_is_string(args[0]))
+        bad_type_exn("open-input-port", "string?", args[0]);
 
-    stream = fopen(minim_string(minim_car(args)), "r");
+    stream = fopen(minim_string(args[0]), "r");
     if (stream == NULL) {
-        fprintf(stderr, "could not open file \"%s\"\n", minim_string(minim_car(args)));
+        fprintf(stderr, "could not open file \"%s\"\n", minim_string(args[0]));
         minim_shutdown(1);
     }
 
@@ -604,17 +604,17 @@ minim_object *open_input_port_proc(minim_object *args) {
     return port;
 }
 
-minim_object *open_output_port_proc(minim_object *args) {
+minim_object *open_output_port_proc(int argc, minim_object **args) {
     // (-> string output-port)
     minim_object *port;
     FILE *stream;
 
-    if (!minim_is_string(minim_car(args)))
-        bad_type_exn("open-output-port", "string?", minim_car(args));
+    if (!minim_is_string(args[0]))
+        bad_type_exn("open-output-port", "string?", args[0]);
     
-    stream = fopen(minim_string(minim_car(args)), "w");
+    stream = fopen(minim_string(args[0]), "w");
     if (stream == NULL) {
-        fprintf(stderr, "could not open file \"%s\"\n", minim_string(minim_car(args)));
+        fprintf(stderr, "could not open file \"%s\"\n", minim_string(args[0]));
         minim_shutdown(1);
     }
 
@@ -623,35 +623,35 @@ minim_object *open_output_port_proc(minim_object *args) {
     return port;
 }
 
-minim_object *close_input_port_proc(minim_object *args) {
+minim_object *close_input_port_proc(int argc, minim_object **args) {
     // (-> input-port)
-    if (!minim_is_input_port(minim_car(args)))
-        bad_type_exn("close-input-port", "input-port?", minim_car(args));
+    if (!minim_is_input_port(args[0]))
+        bad_type_exn("close-input-port", "input-port?", args[0]);
 
-    fclose(minim_port(minim_car(args)));
-    minim_port_unset(minim_car(args), MINIM_PORT_OPEN);
+    fclose(minim_port(args[0]));
+    minim_port_unset(args[0], MINIM_PORT_OPEN);
     return minim_void;
 }
 
-minim_object *close_output_port_proc(minim_object *args) {
+minim_object *close_output_port_proc(int argc, minim_object **args) {
     // (-> output-port)
-    if (!minim_is_output_port(minim_car(args)))
-        bad_type_exn("close-output-port", "output-port?", minim_car(args));
+    if (!minim_is_output_port(args[0]))
+        bad_type_exn("close-output-port", "output-port?", args[0]);
 
-    fclose(minim_port(minim_car(args)));
-    minim_port_unset(minim_car(args), MINIM_PORT_OPEN);
+    fclose(minim_port(args[0]));
+    minim_port_unset(args[0], MINIM_PORT_OPEN);
     return minim_void;
 }
 
-minim_object *read_proc(minim_object *args) {
+minim_object *read_proc(int argc, minim_object **args) {
     // (-> any)
     // (-> input-port any)
     minim_object *in_p, *o;
 
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         in_p = input_port(current_thread());
     } else {
-        in_p = minim_car(args);
+        in_p = args[0];
         if (!minim_is_input_port(in_p))
             bad_type_exn("read", "input-port?", in_p);
     }
@@ -660,16 +660,16 @@ minim_object *read_proc(minim_object *args) {
     return (o == NULL) ? minim_eof : o;
 }
 
-minim_object *read_char_proc(minim_object *args) {
+minim_object *read_char_proc(int argc, minim_object **args) {
     // (-> char)
     // (-> input-port char)
     minim_object *in_p;
     int ch;
     
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         in_p = input_port(current_thread());
     } else {
-        in_p = minim_car(args);
+        in_p = args[0];
         if (!minim_is_input_port(in_p))
             bad_type_exn("read-char", "input-port?", in_p);
     }
@@ -678,16 +678,16 @@ minim_object *read_char_proc(minim_object *args) {
     return (ch == EOF) ? minim_eof : make_char(ch);
 }
 
-minim_object *peek_char_proc(minim_object *args) {
+minim_object *peek_char_proc(int argc, minim_object **args) {
     // (-> char)
     // (-> input-port char)
     minim_object *in_p;
     int ch;
     
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         in_p = input_port(current_thread());
     } else {
-        in_p = minim_car(args);
+        in_p = args[0];
         if (!minim_is_input_port(in_p))
             bad_type_exn("peek-char", "input-port?", in_p);
     }
@@ -697,16 +697,16 @@ minim_object *peek_char_proc(minim_object *args) {
     return (ch == EOF) ? minim_eof : make_char(ch);
 }
 
-minim_object *char_is_ready_proc(minim_object *args) {
+minim_object *char_is_ready_proc(int argc, minim_object **args) {
     // (-> boolean)
     // (-> input-port boolean)
     minim_object *in_p;
     int ch;
 
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         in_p = input_port(current_thread());
     } else {
-        in_p = minim_car(args);
+        in_p = args[0];
         if (!minim_is_input_port(in_p))
             bad_type_exn("peek-char", "input-port?", in_p);
     }
@@ -716,16 +716,16 @@ minim_object *char_is_ready_proc(minim_object *args) {
     return (ch == EOF) ? minim_false : minim_true;
 }
 
-minim_object *display_proc(minim_object *args) {
+minim_object *display_proc(int argc, minim_object **args) {
     // (-> any void)
     // (-> any output-port void)
     minim_object *out_p, *o;
 
-    o = minim_car(args);
-    if (minim_is_null(minim_cdr(args))) {
+    o = args[0];
+    if (argc == 1) {
         out_p = output_port(current_thread());
     } else {
-        out_p = minim_cadr(args);
+        out_p = args[1];
         if (!minim_is_output_port(out_p))
             bad_type_exn("display", "output-port?", out_p);
     }
@@ -734,16 +734,16 @@ minim_object *display_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *write_proc(minim_object *args) {
+minim_object *write_proc(int argc, minim_object **args) {
     // (-> any void)
     // (-> any output-port void)
     minim_object *out_p, *o;
 
-    o = minim_car(args);
-    if (minim_is_null(minim_cdr(args))) {
+    o = args[0];
+    if (argc == 1) {
         out_p = output_port(current_thread());
     } else {
-        out_p = minim_cadr(args);
+        out_p = args[1];
         if (!minim_is_output_port(out_p))
             bad_type_exn("display", "output-port?", out_p);
     }
@@ -752,19 +752,19 @@ minim_object *write_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *write_char_proc(minim_object *args) {
+minim_object *write_char_proc(int argc, minim_object **args) {
     // (-> char void)
     // (-> char output-port void)
     minim_object *out_p, *ch;
 
-    ch = minim_car(args);
+    ch = args[0];
     if (!minim_is_char(ch))
         bad_type_exn("write-char", "char?", ch);
 
-    if (minim_is_null(minim_cdr(args))) {
+    if (argc == 1) {
         out_p = output_port(current_thread());
     } else {
-        out_p = minim_cadr(args);
+        out_p = args[1];
         if (!minim_is_output_port(out_p))
             bad_type_exn("display", "output-port?", out_p);
     }
@@ -773,15 +773,15 @@ minim_object *write_char_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *newline_proc(minim_object *args) {
+minim_object *newline_proc(int argc, minim_object **args) {
     // (-> void)
     // (-> output-port void)
     minim_object *out_p;
 
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         out_p = output_port(current_thread());
     } else {
-        out_p = minim_car(args);
+        out_p = args[0];
         if (!minim_is_output_port(out_p))
             bad_type_exn("display", "output-port?", out_p);
     }

--- a/src/boot/c/list.c
+++ b/src/boot/c/list.c
@@ -74,7 +74,7 @@ minim_object *copy_list(minim_object *xs) {
     return head;
 }
 
-minim_object *for_each(minim_object *proc, minim_object *lsts, minim_object *env) {
+minim_object *for_each(minim_object *proc, minim_object **lsts, minim_object *env) {
     minim_object *it, **lst_arr, **arg_its;
     long argc, i, len0, len;
 

--- a/src/boot/c/list.c
+++ b/src/boot/c/list.c
@@ -25,7 +25,7 @@ long list_length(minim_object *xs) {
     while (!minim_is_null(it)) {
         if (!minim_is_pair(it)) {
             fprintf(stderr, "list_length: not a list");
-            exit(1);
+            minim_shutdown(1);
         }
 
         it = minim_cdr(it);
@@ -98,7 +98,7 @@ minim_object *for_each(minim_object *proc, minim_object *lsts, minim_object *env
             if (len != len0) {
                 fprintf(stderr, "for-each: lists of different lengths\n");
                 fprintf(stderr, "  one list: %ld, second list: %ld\n", len0, len);
-                exit(1);
+                minim_shutdown(1);
             }
         }
 
@@ -147,7 +147,7 @@ minim_object *map_list(minim_object *proc, minim_object *lsts, minim_object *env
             if (len != len0) {
                 fprintf(stderr, "map: lists of different lengths\n");
                 fprintf(stderr, "  one list: %ld, second list: %ld\n", len0, len);
-                exit(1);
+                minim_shutdown(1);
             }
         }
 
@@ -170,7 +170,7 @@ minim_object *map_list(minim_object *proc, minim_object *lsts, minim_object *env
             if (values_buffer_count(th) != 1) {
                 fprintf(stderr, "result arity mismatch\n");
                 fprintf(stderr, "  expected: 1, received: %d\n", values_buffer_count(th));
-                exit(1);
+                minim_shutdown(1);
             } else {
                 result = values_buffer_ref(th, 0);
             }
@@ -576,20 +576,20 @@ minim_object *append_proc(minim_object *args) {
 minim_object *for_each_proc(minim_object *args) {
     // (-> proc list list ... list)
     fprintf(stderr, "andmap: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *map_proc(minim_object *args) {
     fprintf(stderr, "andmap: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *andmap_proc(minim_object *args) {
     fprintf(stderr, "andmap: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *ormap_proc(minim_object *args) {
     fprintf(stderr, "ormap: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }

--- a/src/boot/c/list.c
+++ b/src/boot/c/list.c
@@ -575,21 +575,17 @@ minim_object *append_proc(minim_object *args) {
 
 minim_object *for_each_proc(minim_object *args) {
     // (-> proc list list ... list)
-    fprintf(stderr, "andmap: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("for-each");
 }
 
 minim_object *map_proc(minim_object *args) {
-    fprintf(stderr, "andmap: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("map");
 }
 
 minim_object *andmap_proc(minim_object *args) {
-    fprintf(stderr, "andmap: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("andmap");
 }
 
 minim_object *ormap_proc(minim_object *args) {
-    fprintf(stderr, "ormap: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("ormap");
 }

--- a/src/boot/c/list.c
+++ b/src/boot/c/list.c
@@ -225,367 +225,376 @@ minim_object *ormap(minim_object *proc, minim_object *lst, minim_object *env) {
 //  Primitives
 //
 
-minim_object *is_pair_proc(minim_object *args) {
+minim_object *is_pair_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_pair(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_pair(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *is_list_proc(minim_object *args) {
+minim_object *is_list_proc(int argc, minim_object **args) {
     // (-> any boolean)
     minim_object *thing;
-    for (thing = minim_car(args); minim_is_pair(thing); thing = minim_cdr(thing));
+    for (thing = args[0]; minim_is_pair(thing); thing = minim_cdr(thing));
     return minim_is_null(thing) ? minim_true : minim_false;
 }
 
-minim_object *cons_proc(minim_object *args) {
+minim_object *cons_proc(int argc, minim_object **args) {
     // (-> any any pair)
-    return make_pair(minim_car(args), minim_cadr(args));
+    return make_pair(args[0], args[1]);
 }
 
-minim_object *car_proc(minim_object *args) {
+minim_object *car_proc(int argc, minim_object **args) {
     // (-> pair any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o))
         bad_type_exn("car", "pair?", o);
     return minim_car(o);
 }
 
-minim_object *cdr_proc(minim_object *args) {
+minim_object *cdr_proc(int argc, minim_object **args) {
     // (-> pair any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o))
         bad_type_exn("cdr", "pair?", o);
     return minim_cdr(o);
 }
 
-minim_object *caar_proc(minim_object *args) {
+minim_object *caar_proc(int argc, minim_object **args) {
     // (-> (pairof pair any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)))
         bad_type_exn("caar", "(pairof pair? any)", o);
     return minim_caar(o);
 }
 
-minim_object *cadr_proc(minim_object *args) {
+minim_object *cadr_proc(int argc, minim_object **args) {
     // (-> (pairof any pair) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)))
         bad_type_exn("cadr", "(pairof any pair)", o);
     return minim_cadr(o);
 }
 
-minim_object *cdar_proc(minim_object *args) {
+minim_object *cdar_proc(int argc, minim_object **args) {
     // (-> (pairof pair any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)))
         bad_type_exn("cdar", "(pairof pair? any)", o);
     return minim_cdar(o);
 }
 
-minim_object *cddr_proc(minim_object *args) {
+minim_object *cddr_proc(int argc, minim_object **args) {
     // (-> (pairof any pair) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)))
         bad_type_exn("cddr", "(pairof any pair)", o);
     return minim_cddr(o);
 }
 
-minim_object *caaar_proc(minim_object *args) {
+minim_object *caaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof pair any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) || !minim_is_pair(minim_caar(o)))
         bad_type_exn("caaar", "(pairof (pairof pair? any) any)", o);
     return minim_car(minim_caar(o));
 }
 
-minim_object *caadr_proc(minim_object *args) {
+minim_object *caadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof pair any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) || !minim_is_pair(minim_cadr(o)))
         bad_type_exn("caadr", "(pairof any (pairof pair? any))", o);
     return minim_car(minim_cadr(o));
 }
 
-minim_object *cadar_proc(minim_object *args) {
+minim_object *cadar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any pair) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) || !minim_is_pair(minim_cdar(o)))
         bad_type_exn("cadar", "(pairof (pairof any pair?) any)", o);
     return minim_car(minim_cdar(o));
 }
 
-minim_object *caddr_proc(minim_object *args) {
+minim_object *caddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any pair)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) || !minim_is_pair(minim_cddr(o)))
         bad_type_exn("caddr", "(pairof any (pairof any pair))", o);
     return minim_car(minim_cddr(o));
 }
 
-minim_object *cdaar_proc(minim_object *args) {
+minim_object *cdaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof pair any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) || !minim_is_pair(minim_caar(o)))
         bad_type_exn("cdaar", "(pairof (pairof pair? any) any)", o);
     return minim_cdr(minim_caar(o));
 }
 
-minim_object *cdadr_proc(minim_object *args) {
+minim_object *cdadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof pair any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) || !minim_is_pair(minim_cadr(o)))
         bad_type_exn("cdadr", "(pairof any (pairof pair? any))", o);
     return minim_cdr(minim_cadr(o));
 }
 
-minim_object *cddar_proc(minim_object *args) {
+minim_object *cddar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any pair) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) || !minim_is_pair(minim_cdar(o)))
         bad_type_exn("cddar", "(pairof (pairof any pair?) any)", o);
     return minim_cdr(minim_cdar(o));
 }
 
-minim_object *cdddr_proc(minim_object *args) {
+minim_object *cdddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any pair)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) || !minim_is_pair(minim_cddr(o)))
         bad_type_exn("cdddr", "(pairof any (pairof any pair?))", o);
     return minim_cdr(minim_cddr(o));
 }
 
-minim_object *caaaar_proc(minim_object *args) {
+minim_object *caaaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof (pairof pair any) any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_caar(o)) || !minim_is_pair(minim_car(minim_caar(o))))
         bad_type_exn("caaaar", "(pairof (pairof (pairof pair? any) any) any)", o);
     return minim_caar(minim_caar(o));
 }
 
-minim_object *caaadr_proc(minim_object *args) {
+minim_object *caaadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof (pairof pair any) any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cadr(o)) || !minim_is_pair(minim_car(minim_cadr(o))))
         bad_type_exn("caaadr", "(pairof any (pairof (pairof pair? any) any))", o);
     return minim_caar(minim_cadr(o));
 }
 
-minim_object *caadar_proc(minim_object *args) {
+minim_object *caadar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any (pairof pair any)) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_cdar(o)) || !minim_is_pair(minim_car(minim_cdar(o))))
         bad_type_exn("caadar", "(pairof (pairof any (pairof pair? any)) any)", o);
     return minim_caar(minim_cdar(o));
 }
 
-minim_object *caaddr_proc(minim_object *args) {
+minim_object *caaddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any (pairof pair any))) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cddr(o)) ||  !minim_is_pair(minim_car(minim_cddr(o))))
         bad_type_exn("caaddr", "(pairof any (pairof any (pairof pair? any)))", o);
     return minim_caar(minim_cddr(o));
 }
 
-minim_object *cadaar_proc(minim_object *args) {
+minim_object *cadaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof (pairof any pair) any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_caar(o)) || !minim_is_pair(minim_cdr(minim_caar(o))))
         bad_type_exn("cadaar", "(pairof (pairof (pairof any pair?) any) any)", o);
     return minim_cadr(minim_caar(o));
 }
 
-minim_object *cadadr_proc(minim_object *args) {
+minim_object *cadadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof (pairof any pair) any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cadr(o)) || !minim_is_pair(minim_cdr(minim_cadr(o))))
         bad_type_exn("cadadr", "(pairof any (pairof (pairof any pair?) any))", o);
     return minim_cadr(minim_cadr(o));
 }
 
-minim_object *caddar_proc(minim_object *args) {
+minim_object *caddar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any (pairof any pair)) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_cdar(o)) || !minim_is_pair(minim_cdr(minim_cdar(o))))
         bad_type_exn("caddar", "(pairof (pairof any (pairof any pair?) any)", o);
     return minim_cadr(minim_cdar(o));
 }
 
-minim_object *cadddr_proc(minim_object *args) {
+minim_object *cadddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any (pairof any pair))) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cddr(o)) || !minim_is_pair(minim_cdr(minim_cddr(o))))
         bad_type_exn("cadddr", "(pairof any (pairof any (pairof any pair?)))", o);
     return minim_cadr(minim_cddr(o));
 }
 
-minim_object *cdaaar_proc(minim_object *args) {
+minim_object *cdaaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof (pairof pair any) any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_caar(o)) || !minim_is_pair(minim_car(minim_caar(o))))
         bad_type_exn("cdaaar", "(pairof (pairof (pairof pair? any) any) any)", o);
     return minim_cdar(minim_caar(o));
 }
 
-minim_object *cdaadr_proc(minim_object *args) {
+minim_object *cdaadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof (pairof pair any) any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cadr(o)) || !minim_is_pair(minim_car(minim_cadr(o))))
         bad_type_exn("cdaadr", "(pairof any (pairof (pairof pair? any) any))", o);
     return minim_cdar(minim_cadr(o));
 }
 
-minim_object *cdadar_proc(minim_object *args) {
+minim_object *cdadar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any (pairof pair any)) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_cdar(o)) || !minim_is_pair(minim_car(minim_cdar(o))))
         bad_type_exn("cdadar", "(pairof (pairof any (pairof pair? any)) any)", o);
     return minim_cdar(minim_cdar(o));
 }
 
-minim_object *cdaddr_proc(minim_object *args) {
+minim_object *cdaddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any (pairof pair any))) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cddr(o)) ||  !minim_is_pair(minim_car(minim_cddr(o))))
         bad_type_exn("cdaddr", "(pairof any (pairof any (pairof pair? any)))", o);
     return minim_cdar(minim_cddr(o));
 }
 
-minim_object *cddaar_proc(minim_object *args) {
+minim_object *cddaar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof (pairof any pair) any) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_caar(o)) || !minim_is_pair(minim_cdr(minim_caar(o))))
         bad_type_exn("cddaar", "(pairof (pairof (pairof any pair?) any) any)", o);
     return minim_cddr(minim_caar(o));
 }
 
-minim_object *cddadr_proc(minim_object *args) {
+minim_object *cddadr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof (pairof any pair) any)) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cadr(o)) || !minim_is_pair(minim_cdr(minim_cadr(o))))
         bad_type_exn("cddadr", "(pairof any (pairof (pairof any pair?) any))", o);
     return minim_cddr(minim_cadr(o));
 }
 
-minim_object *cdddar_proc(minim_object *args) {
+minim_object *cdddar_proc(int argc, minim_object **args) {
     // (-> (pairof (pairof any (pairof any pair)) any) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_car(o)) ||
         !minim_is_pair(minim_cdar(o)) || !minim_is_pair(minim_cdr(minim_cdar(o))))
         bad_type_exn("cdddar", "(pairof (pairof any (pairof any pair?) any)", o);
     return minim_cddr(minim_cdar(o));
 }
 
-minim_object *cddddr_proc(minim_object *args) {
+minim_object *cddddr_proc(int argc, minim_object **args) {
     // (-> (pairof any (pairof any (pairof any pair))) any)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o) || !minim_is_pair(minim_cdr(o)) ||
         !minim_is_pair(minim_cddr(o)) || !minim_is_pair(minim_cdr(minim_cddr(o))))
         bad_type_exn("cddddr", "(pairof any (pairof any (pairof any pair?)))", o);
     return minim_cddr(minim_cddr(o));
 }
 
-minim_object *set_car_proc(minim_object *args) {
+minim_object *set_car_proc(int argc, minim_object **args) {
     // (-> pair any void)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o))
         bad_type_exn("set-car!", "pair?", o);
-    minim_car(o) = minim_cadr(args);
+    minim_car(o) = args[1];
     return minim_void;
 }
 
-minim_object *set_cdr_proc(minim_object *args) {
+minim_object *set_cdr_proc(int argc, minim_object **args) {
     // (-> pair any void)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_pair(o))
         bad_type_exn("set-cdr!", "pair?", o);
-    minim_cdr(o) = minim_cadr(args);
+    minim_cdr(o) = args[1];
     return minim_void;
 }
 
-minim_object *list_proc(minim_object *args) {
+minim_object *list_proc(int argc, minim_object **args) {
     // (-> any ... list)
-    return args;
+    minim_object *lst;
+    int i;
+
+    lst = minim_null;
+    for (i = argc - 1; i >= 0; --i)
+        lst = make_pair(args[i], lst);
+
+    return lst;
 }
 
-minim_object *length_proc(minim_object *args) {
+minim_object *length_proc(int argc, minim_object **args) {
     // (-> list non-negative-integer?)
     minim_object *it;
     long length;
 
     length = 0;
-    for (it = minim_car(args); minim_is_pair(it); it = minim_cdr(it))
+    for (it = args[0]; minim_is_pair(it); it = minim_cdr(it))
         length += 1;
 
     if (!minim_is_null(it))
-        bad_type_exn("length", "list?", minim_car(args));
+        bad_type_exn("length", "list?", args[0]);
+
     return make_fixnum(length);
 }
 
-minim_object *reverse_proc(minim_object *args) {
+minim_object *reverse_proc(int argc, minim_object **args) {
     // (-> list list)
     minim_object *head, *it;
     
     head = minim_null;
-    for (it = minim_car(args); minim_is_pair(it); it = minim_cdr(it))
+    for (it = args[0]; minim_is_pair(it); it = minim_cdr(it))
         head = make_pair(minim_car(it), head);
 
     if (!minim_is_null(it))
-        bad_type_exn("reverse", "expected list?", minim_car(args));
+        bad_type_exn("reverse", "expected list?", args[0]);
     return head;
 }
 
-minim_object *append_proc(minim_object *args) {
+minim_object *append_proc(int argc, minim_object **args) {
     // (-> list ... list)
-    minim_object *head, *lst_it, *it, *it2;
+    minim_object *head, *lst_it, *it;
+    int i;
 
     head = NULL;
-    for (it = args; !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_null(minim_car(it))) {
-            for (it2 = minim_car(it); minim_is_pair(it2); it2 = minim_cdr(it2)) {
+    for (i = 0; i < argc; ++i) {
+        if (!minim_is_null(args[i])) {
+            for (it = args[i]; minim_is_pair(it); it = minim_cdr(it)) {
                 if (head) {
-                    minim_cdr(lst_it) = make_pair(minim_car(it2), minim_null);
+                    minim_cdr(lst_it) = make_pair(minim_car(it), minim_null);
                     lst_it = minim_cdr(lst_it);
                 } else {
-                    head = make_pair(minim_car(it2), minim_null);
+                    head = make_pair(minim_car(it), minim_null);
                     lst_it = head;
                 }
             }
 
-            if (!minim_is_null(it2))
-                bad_type_exn("append", "expected list?", minim_car(it));
+            if (!minim_is_null(it))
+                bad_type_exn("append", "expected list?", args[i]);
         }
     }
 
     return head ? head : minim_null;
 }
 
-minim_object *for_each_proc(minim_object *args) {
+minim_object *for_each_proc(int argc, minim_object **args) {
     // (-> proc list list ... list)
     uncallable_prim_exn("for-each");
 }
 
-minim_object *map_proc(minim_object *args) {
+minim_object *map_proc(int argc, minim_object **args) {
     uncallable_prim_exn("map");
 }
 
-minim_object *andmap_proc(minim_object *args) {
+minim_object *andmap_proc(int argc, minim_object **args) {
     uncallable_prim_exn("andmap");
 }
 
-minim_object *ormap_proc(minim_object *args) {
+minim_object *ormap_proc(int argc, minim_object **args) {
     uncallable_prim_exn("ormap");
 }

--- a/src/boot/c/minim.c
+++ b/src/boot/c/minim.c
@@ -108,6 +108,5 @@ int main(int argc, char **argv) {
         }
     }
 
-    GC_finalize();
-    return stack_top;
+    minim_shutdown(stack_top);
 }

--- a/src/boot/c/number.c
+++ b/src/boot/c/number.c
@@ -43,7 +43,7 @@ minim_object *sub_proc(int argc, minim_object **args) {
     if (!minim_is_fixnum(args[0]))
         bad_type_exn("-", "integer?", args[0]);
     
-    if (minim_is_null(minim_cdr(args))) {
+    if (argc == 1) {
         result = -(minim_fixnum(args[0]));
     } else {
         result = minim_fixnum(args[0]);

--- a/src/boot/c/number.c
+++ b/src/boot/c/number.c
@@ -15,193 +15,187 @@ minim_object *make_fixnum(long v) {
 //  Primitives
 //
 
-minim_object *is_fixnum_proc(minim_object *args) {
+minim_object *is_fixnum_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_fixnum(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_fixnum(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *add_proc(minim_object *args) {
+minim_object *add_proc(int argc, minim_object **args) {
     // (-> integer ... integer)
-    long result = 0;
- 
-    while (!minim_is_null(args)) {
-        if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("+", "integer?", minim_car(args));
-        result += minim_fixnum(minim_car(args));
-        args = minim_cdr(args);
+    long result;
+    int i;
+    
+    result = 0;
+    for (i = 0; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn("+", "integer?", args[i]);
+        result += minim_fixnum(args[i]);
     }
 
     return make_fixnum(result);
 }
 
-minim_object *sub_proc(minim_object *args) {
+minim_object *sub_proc(int argc, minim_object **args) {
     // (-> integer integer ... integer)
     long result;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-        bad_type_exn("-", "integer?", minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn("-", "integer?", args[0]);
     
     if (minim_is_null(minim_cdr(args))) {
-        result = -(minim_fixnum(minim_car(args)));
+        result = -(minim_fixnum(args[0]));
     } else {
-        result = minim_fixnum(minim_car(args));
-        args = minim_cdr(args);
-        while (!minim_is_null(args)) {
-            if (!minim_is_fixnum(minim_car(args)))
-                bad_type_exn("-", "integer?", minim_car(args));
-            result -= minim_fixnum(minim_car(args));
-            args = minim_cdr(args);
+        result = minim_fixnum(args[0]);
+        for (i = 1; i < argc; ++i) {
+            if (!minim_is_fixnum(args[i]))
+                bad_type_exn("-", "integer?", args[i]);
+            result -= minim_fixnum(args[i]);
         }
     }
 
     return make_fixnum(result);
 }
 
-minim_object *mul_proc(minim_object *args) {
+minim_object *mul_proc(int argc, minim_object **args) {
     // (-> integer ... integer)
-    long result = 1;
-
-    while (!minim_is_null(args)) {
-        if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("*", "integer?", minim_car(args));
-        result *= minim_fixnum(minim_car(args));
-        args = minim_cdr(args);
+    long result;
+    int i;
+    
+    result = 1;
+    for (i = 0; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn("*", "integer?", args[i]);
+        result *= minim_fixnum(args[i]);
     }
 
     return make_fixnum(result);
 }
 
-minim_object *div_proc(minim_object *args) {
+minim_object *div_proc(int argc, minim_object **args) {
     // (-> integer integer integer)
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("/", "integer?", minim_car(args));
-    if (!minim_is_fixnum(minim_cadr(args)))
-            bad_type_exn("/", "integer?", minim_cadr(args));
+    if (!minim_is_fixnum(args[0]))
+            bad_type_exn("/", "integer?", args[0]);
+    if (!minim_is_fixnum(args[1]))
+            bad_type_exn("/", "integer?", args[1]);
 
-    return make_fixnum(minim_fixnum(minim_car(args)) /
-                       minim_fixnum(minim_cadr(args)));
+    return make_fixnum(minim_fixnum(args[0]) / minim_fixnum(args[1]));
 }
 
-minim_object *remainder_proc(minim_object *args) {
+minim_object *remainder_proc(int argc, minim_object **args) {
     // (-> integer integer integer)
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("remainder", "integer?", minim_car(args));
-    if (!minim_is_fixnum(minim_cadr(args)))
-            bad_type_exn("remainder", "integer?", minim_cadr(args));
+    if (!minim_is_fixnum(args[0]))
+            bad_type_exn("remainder", "integer?", args[0]);
+    if (!minim_is_fixnum(args[1]))
+            bad_type_exn("remainder", "integer?", args[1]);
 
-    return make_fixnum(minim_fixnum(minim_car(args)) %
-                       minim_fixnum(minim_cadr(args)));
+    return make_fixnum(minim_fixnum(args[0]) % minim_fixnum(args[1]));
 }
 
-minim_object *modulo_proc(minim_object *args) {
+minim_object *modulo_proc(int argc, minim_object **args) {
     // (-> integer integer integer)
     long result;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("modulo", "integer?", minim_car(args));
-    if (!minim_is_fixnum(minim_cadr(args)))
-            bad_type_exn("modulo", "integer?", minim_cadr(args));
+    if (!minim_is_fixnum(args[0]))
+            bad_type_exn("modulo", "integer?", args[0]);
+    if (!minim_is_fixnum(args[1]))
+            bad_type_exn("modulo", "integer?", args[1]);
 
-    result = minim_fixnum(minim_car(args)) % minim_fixnum(minim_cadr(args));
-    if ((minim_fixnum(minim_car(args)) < 0) != (minim_fixnum(minim_cadr(args)) < 0))
-        result += minim_fixnum(minim_cadr(args));
+    result = minim_fixnum(args[0]) % minim_fixnum(args[1]);
+    if ((minim_fixnum(args[0]) < 0) != (minim_fixnum(args[1]) < 0))
+        result += minim_fixnum(args[1]);
     return make_fixnum(result);
 }
 
-minim_object *number_eq_proc(minim_object *args) {
+minim_object *number_eq_proc(int argc, minim_object **args) {
     // (-> number number number ... boolean)
-    minim_object *it;
     long x0;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("=", "number?", minim_car(args));
-    x0 = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn("=", "number?", args[0]);
+    x0 = minim_fixnum(args[0]);
 
-    for (it = minim_cdr(args); !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_fixnum(minim_car(it)))
-            bad_type_exn("=", "number?", minim_car(it));
-        
-        if (x0 != minim_fixnum(minim_car(it)))
+    for (i = 1; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn("=", "number?", args[i]);
+        if (x0 != minim_fixnum(args[i]))
             return minim_false;
     }
 
     return minim_true;
 }
 
-minim_object *number_ge_proc(minim_object *args) { 
+minim_object *number_ge_proc(int argc, minim_object **args) { 
     // (-> number number number ... boolean)
-    minim_object *it;
     long x0;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn(">=", "number?", minim_car(args));
-    x0 = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn(">=", "number?", args[0]);
+    x0 = minim_fixnum(args[0]);
 
-    for (it = minim_cdr(args); !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_fixnum(minim_car(it)))
-            bad_type_exn(">=", "number?", minim_car(it));
-        
-        if (x0 < minim_fixnum(minim_car(it)))
+    for (i = 1; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn(">=", "number?", args[i]);
+        if (x0 < minim_fixnum(args[i]))
             return minim_false;
     }
 
     return minim_true;
 }
 
-minim_object *number_le_proc(minim_object *args) { 
+minim_object *number_le_proc(int argc, minim_object **args) { 
     // (-> number number number ... boolean)
-    minim_object *it;
     long x0;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("<=", "number?", minim_car(args));
-    x0 = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn("<=", "number?", args[0]);
+    x0 = minim_fixnum(args[0]);
 
-    for (it = minim_cdr(args); !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_fixnum(minim_car(it)))
-            bad_type_exn("<=", "number?", minim_car(it));
-        
-        if (x0 > minim_fixnum(minim_car(it)))
+    for (i = 1; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn("<=", "number?", args[i]);
+        if (x0 > minim_fixnum(args[i]))
             return minim_false;
     }
 
     return minim_true;
 }
 
-minim_object *number_gt_proc(minim_object *args) { 
+minim_object *number_gt_proc(int argc, minim_object **args) { 
     // (-> number number number ... boolean)
-    minim_object *it;
     long x0;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn(">", "number?", minim_car(args));
-    x0 = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn(">", "number?", args[0]);
+    x0 = minim_fixnum(args[0]);
 
-    for (it = minim_cdr(args); !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_fixnum(minim_car(it)))
-            bad_type_exn(">", "number?", minim_car(it));
-        
-        if (x0 <= minim_fixnum(minim_car(it)))
+    for (i = 1; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn(">", "number?", args[i]);
+        if (x0 <= minim_fixnum(args[i]))
             return minim_false;
     }
 
     return minim_true;
 }
 
-minim_object *number_lt_proc(minim_object *args) { 
+minim_object *number_lt_proc(int argc, minim_object **args) { 
     // (-> number number number ... boolean)
-    minim_object *it;
     long x0;
+    int i;
 
-    if (!minim_is_fixnum(minim_car(args)))
-            bad_type_exn("<", "number?", minim_car(args));
-    x0 = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]))
+        bad_type_exn("<", "number?", args[0]);
+    x0 = minim_fixnum(args[0]);
 
-    for (it = minim_cdr(args); !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_fixnum(minim_car(it)))
-            bad_type_exn("<", "number?", minim_car(it));
-        
-        if (x0 >= minim_fixnum(minim_car(it)))
+    for (i = 1; i < argc; ++i) {
+        if (!minim_is_fixnum(args[i]))
+            bad_type_exn("<", "number?", args[i]);
+        if (x0 >= minim_fixnum(args[i]))
             return minim_false;
     }
 

--- a/src/boot/c/object.c
+++ b/src/boot/c/object.c
@@ -92,43 +92,43 @@ int minim_is_equal(minim_object *a, minim_object *b) {
 //  Primitives
 //
 
-minim_object *is_null_proc(minim_object *args) {
+minim_object *is_null_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_null(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_null(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *is_void_proc(minim_object *args) {
+minim_object *is_void_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_void(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_void(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *is_eof_proc(minim_object *args) {
+minim_object *is_eof_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_eof(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_eof(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *is_bool_proc(minim_object *args) {
+minim_object *is_bool_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     return (minim_is_true(o) || minim_is_false(o)) ? minim_true : minim_false;
 }
 
-minim_object *not_proc(minim_object *args) {
+minim_object *not_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_false(minim_car(args)) ? minim_true : minim_false;   
+    return minim_is_false(args[0]) ? minim_true : minim_false;   
 }
 
-minim_object *eq_proc(minim_object *args) {
+minim_object *eq_proc(int argc, minim_object **args) {
     // (-> any any boolean)
-    return minim_is_eq(minim_car(args), minim_cadr(args)) ? minim_true : minim_false;
+    return minim_is_eq(args[0], args[1]) ? minim_true : minim_false;
 }
 
-minim_object *equal_proc(minim_object *args) {
+minim_object *equal_proc(int argc, minim_object **args) {
     // (-> any any boolean)
-    return minim_is_equal(minim_car(args), minim_cadr(args)) ? minim_true : minim_false;
+    return minim_is_equal(args[0], args[1]) ? minim_true : minim_false;
 }
 
-minim_object *void_proc(minim_object *args) {
+minim_object *void_proc(int argc, minim_object **args) {
     // (-> void)
     return minim_void;
 }

--- a/src/boot/c/procedure.c
+++ b/src/boot/c/procedure.c
@@ -67,8 +67,7 @@ minim_object *is_procedure_proc(minim_object *args) {
 }
 
 minim_object *call_with_values_proc(minim_object *args) {
-    fprintf(stderr, "andmap: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("call-with-values");
 }
 
 minim_object *values_proc(minim_object *args) {
@@ -90,11 +89,9 @@ minim_object *values_proc(minim_object *args) {
 }
 
 minim_object *eval_proc(minim_object *args) {
-    fprintf(stderr, "eval: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("eval");
 }
 
 minim_object *apply_proc(minim_object *args) {
-    fprintf(stderr, "eval: should not be called directly");
-    minim_shutdown(1);
+    uncallable_prim_exn("apply");
 }

--- a/src/boot/c/procedure.c
+++ b/src/boot/c/procedure.c
@@ -11,7 +11,7 @@
 static void set_arity(proc_arity *arity, short min_arity, short max_arity) {
     if (min_arity > ARG_MAX || max_arity > ARG_MAX) {
         fprintf(stderr, "primitive procedure intialized with too large an arity: [%d, %d]", min_arity, max_arity);
-        exit(1);
+        minim_shutdown(1);
     } else {
         arity->arity_min = min_arity;
         arity->arity_max = max_arity;
@@ -68,7 +68,7 @@ minim_object *is_procedure_proc(minim_object *args) {
 
 minim_object *call_with_values_proc(minim_object *args) {
     fprintf(stderr, "andmap: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *values_proc(minim_object *args) {
@@ -91,10 +91,10 @@ minim_object *values_proc(minim_object *args) {
 
 minim_object *eval_proc(minim_object *args) {
     fprintf(stderr, "eval: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *apply_proc(minim_object *args) {
     fprintf(stderr, "eval: should not be called directly");
-    exit(1);
+    minim_shutdown(1);
 }

--- a/src/boot/c/procedure.c
+++ b/src/boot/c/procedure.c
@@ -60,38 +60,33 @@ void resize_values_buffer(minim_thread *th, int size) {
 //  Procedure
 //
 
-minim_object *is_procedure_proc(minim_object *args) {
+minim_object *is_procedure_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     return (minim_is_prim_proc(o) || minim_is_closure_proc(o)) ? minim_true : minim_false;
 }
 
-minim_object *call_with_values_proc(minim_object *args) {
+minim_object *call_with_values_proc(int argc, minim_object **args) {
     uncallable_prim_exn("call-with-values");
 }
 
-minim_object *values_proc(minim_object *args) {
+minim_object *values_proc(int argc, minim_object **args) {
+    // (-> any ... (values any ...))
     minim_thread *th;
-    long i, len;
 
     th = current_thread();
-    len = list_length(args);
-    if (len > values_buffer_size(th))
-        resize_values_buffer(th, len);
+    if (argc > values_buffer_size(th))
+        resize_values_buffer(th, argc);
     
-    values_buffer_count(th) = len;
-    for (i = 0; i < len; ++i) {
-        values_buffer_ref(th, i) = minim_car(args);
-        args = minim_cdr(args);
-    }
-    
+    values_buffer_count(th) = argc;
+    memcpy(values_buffer(th), args, argc * sizeof(minim_object *));    
     return minim_values;
 }
 
-minim_object *eval_proc(minim_object *args) {
+minim_object *eval_proc(int argc, minim_object **args) {
     uncallable_prim_exn("eval");
 }
 
-minim_object *apply_proc(minim_object *args) {
+minim_object *apply_proc(int argc, minim_object **args) {
     uncallable_prim_exn("apply");
 }

--- a/src/boot/c/string.c
+++ b/src/boot/c/string.c
@@ -103,7 +103,7 @@ minim_object *string_ref_proc(minim_object *args) {
     if (idx >= len) {
         fprintf(stderr, "string-ref: index out of bounds\n");
         fprintf(stderr, " string: %s, length: %ld, index %ld\n", str, len, idx);
-        exit(1);
+        minim_shutdown(1);
     }
 
     return make_char((int) str[idx]);
@@ -130,7 +130,7 @@ minim_object *string_set_proc(minim_object *args) {
     if (idx >= len) {
         fprintf(stderr, "string-set!: index out of bounds\n");
         fprintf(stderr, " string: %s, length: %ld, index %ld\n", str, len, idx);
-        exit(1);
+        minim_shutdown(1);
     }
 
     str[idx] = c;

--- a/src/boot/c/string.c
+++ b/src/boot/c/string.c
@@ -34,30 +34,30 @@ minim_object *make_string2(char *s) {
     return ((minim_object *) o);
 }
 
-minim_object *is_string_proc(minim_object *args) {
+minim_object *is_string_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_string(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_string(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *make_string_proc(minim_object *args) {
+minim_object *make_string_proc(int argc, minim_object **args) {
     // (-> non-negative-integer string)
     // (-> non-negative-integer char string)
     char *str;
     long len, i;
     int c;
 
-    if (!minim_is_fixnum(minim_car(args)) || minim_fixnum(minim_car(args)) < 0)
-        bad_type_exn("make-string", "non-negative-integer?", minim_car(args));
-    len = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]) || minim_fixnum(args[0]) < 0)
+        bad_type_exn("make-string", "non-negative-integer?", args[0]);
+    len = minim_fixnum(args[0]);
 
-    if (minim_is_null(minim_cdr(args))) {
+    if (argc == 1) {
         // 1st case
         c = 'a';
     } else {
         // 2nd case
-        if (!minim_is_char(minim_cadr(args)))
-            bad_type_exn("make-string", "char?", minim_cadr(args));
-        c = minim_char(minim_cadr(args));
+        if (!minim_is_char(args[1]))
+            bad_type_exn("make-string", "char?", args[1]);
+        c = minim_char(args[1]);
     }
 
     str = GC_alloc_atomic((len + 1) * sizeof(char));    
@@ -68,44 +68,43 @@ minim_object *make_string_proc(minim_object *args) {
     return make_string2(str);
 }
 
-minim_object *string_proc(minim_object *args) {
+minim_object *string_proc(int argc, minim_object **args) {
     // (-> char ... string)
-    long len, i;
     char *str;
+    int i;
 
-    len = list_length(args);
-    str = GC_alloc_atomic((len + 1) * sizeof(char));
-    for (i = 0; i < len; ++i) {
-        if (!minim_is_char(minim_car(args)))
-            bad_type_exn("make-string", "char?", minim_car(args));
-        str[i] = minim_char(minim_car(args));
-        args = minim_cdr(args);
+    str = GC_alloc_atomic((argc + 1) * sizeof(char));
+    str[argc] = '\0';
+
+    for (i = 0; i < argc; ++i) {
+        if (!minim_is_char(args[i]))
+            bad_type_exn("make-string", "char?", args[i]);
+        str[i] = minim_char(args[i]);
     }
-    str[i] = '\0';
 
     return make_string2(str);
 }
 
-minim_object *string_length_proc(minim_object *args) {
+minim_object *string_length_proc(int argc, minim_object **args) {
     // (-> string integer)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_string(o))
         bad_type_exn("string-length", "string?", o);
     return make_fixnum(strlen(minim_string(o)));
 }
 
-minim_object *string_ref_proc(minim_object *args) {
+minim_object *string_ref_proc(int argc, minim_object **args) {
     // (-> string non-negative-integer char)
     char *str;
     long len, idx;
 
-    if (!minim_is_string(minim_car(args)))
-        bad_type_exn("string-ref", "string?", minim_car(args));
-    if (!minim_is_fixnum(minim_cadr(args)) || minim_fixnum(minim_cadr(args)) < 0)
+    if (!minim_is_string(args[0]))
+        bad_type_exn("string-ref", "string?", args[0]);
+    if (!minim_is_fixnum(args[1]) || minim_fixnum(args[1]) < 0)
         bad_type_exn("string-ref", "non-negative-integer?", minim_cdar(args));
 
-    str = minim_string(minim_car(args));
-    idx = minim_fixnum(minim_cadr(args));
+    str = minim_string(args[0]);
+    idx = minim_fixnum(args[1]);
     len = strlen(str);
 
     if (idx >= len)
@@ -114,22 +113,22 @@ minim_object *string_ref_proc(minim_object *args) {
     return make_char((int) str[idx]);
 }
 
-minim_object *string_set_proc(minim_object *args) {
+minim_object *string_set_proc(int argc, minim_object **args) {
     // (-> string non-negative-integer char void)
     char *str;
     long len, idx;
     char c;
 
-    if (!minim_is_string(minim_car(args)))
-        bad_type_exn("string-set!", "string?", minim_car(args));
-    if (!minim_is_fixnum(minim_cadr(args)) || minim_fixnum(minim_cadr(args)) < 0)
+    if (!minim_is_string(args[0]))
+        bad_type_exn("string-set!", "string?", args[0]);
+    if (!minim_is_fixnum(args[1]) || minim_fixnum(args[1]) < 0)
         bad_type_exn("string-set!", "non-negative-integer?", minim_cdar(args));
-    if (!minim_is_char(minim_car(minim_cddr(args))))
-        bad_type_exn("string-set!", "char?", minim_car(minim_cddr(args)));
+    if (!minim_is_char(args[2]))
+        bad_type_exn("string-set!", "char?", args[2]);
 
-    str = minim_string(minim_car(args));
-    idx = minim_fixnum(minim_cadr(args));
-    c = minim_char(minim_car(minim_cddr(args)));
+    str = minim_string(args[0]);
+    idx = minim_fixnum(args[1]);
+    c = minim_char(args[2]);
     len = strlen(str);
 
     if (idx >= len)
@@ -139,60 +138,63 @@ minim_object *string_set_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *string_append_proc(minim_object *args) {
-    minim_object *it;
+minim_object *string_append_proc(int argc, minim_object **args) {
+    // (-> string ... string)
     char *str;
-    long len, i, j;
+    long len, j, l;
+    int i;
 
-    len = 0; i = 0;
-    for (it = args; !minim_is_null(it); it = minim_cdr(it)) {
-        if (!minim_is_string(minim_car(it)))
-            bad_type_exn("string-append", "string?", minim_car(it));
-        len += strlen(minim_string(minim_car(it)));
+    len = 0;
+    for (i = 0; i < argc; ++i) {
+        if (!minim_is_string(args[i]))
+            bad_type_exn("string-append", "string?", args[i]);
+        len += strlen(minim_string(args[i]));
     }
 
     str = GC_alloc_atomic((len + 1) * sizeof(char));
-    for (it = args; !minim_is_null(it); it = minim_cdr(it)) {
-        j = strlen(minim_string(minim_car(it)));
-        strcpy(&str[i], minim_string(minim_car(it)));
-        i += j;
-    }
+    str[len] = '\0';
 
-    str[len] = '\0';    
+    j = 0;
+    for (i = 0; i < argc; ++i) {
+        l = strlen(minim_string(args[i]));
+        strcpy(&str[j], minim_string(args[i]));
+        j += l;
+    }
+   
     return make_string2(str);
 }
 
-minim_object *number_to_string_proc(minim_object *args) {
+minim_object *number_to_string_proc(int argc, minim_object **args) {
     // (-> number string)
     minim_object *o;
     char buffer[30];
 
-    o = minim_car(args);
+    o = args[0];
     if (!minim_is_fixnum(o))
         bad_type_exn("number->string", "number?", o);
     sprintf(buffer, "%ld", minim_fixnum(o));
     return make_string(buffer);
 }
 
-minim_object *string_to_number_proc(minim_object *args) {
+minim_object *string_to_number_proc(int argc, minim_object **args) {
     // (-> string number)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_string(o))
         bad_type_exn("string->number", "string?", o);
     return make_fixnum(atoi(minim_string(o)));
 }
 
-minim_object *symbol_to_string_proc(minim_object *args) {
+minim_object *symbol_to_string_proc(int argc, minim_object **args) {
     // (-> symbol string)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_symbol(o))
         bad_type_exn("symbol->string", "symbol?", o);
     return make_string(minim_symbol(o));
 }
 
-minim_object *string_to_symbol_proc(minim_object *args) {
+minim_object *string_to_symbol_proc(int argc, minim_object **args) {
     // (-> string symbol)
-    minim_object *o = minim_car(args);
+    minim_object *o = args[0];
     if (!minim_is_string(o))
         bad_type_exn("string->symbol", "string?", o);
     return intern(minim_string(o));

--- a/src/boot/c/string.c
+++ b/src/boot/c/string.c
@@ -4,6 +4,14 @@
 
 #include "../minim.h"
 
+static void string_out_of_bounds_exn(const char *name, const char *str, long idx) {
+    fprintf(stderr, "%s, index out of bounds\n", name);
+    fprintf(stderr, " string: %s\n", str);
+    fprintf(stderr, " length: %ld\n", strlen(str));
+    fprintf(stderr, " index:  %ld\n", idx);
+    minim_shutdown(1);
+}
+
 //
 //  Primitives
 //
@@ -100,11 +108,8 @@ minim_object *string_ref_proc(minim_object *args) {
     idx = minim_fixnum(minim_cadr(args));
     len = strlen(str);
 
-    if (idx >= len) {
-        fprintf(stderr, "string-ref: index out of bounds\n");
-        fprintf(stderr, " string: %s, length: %ld, index %ld\n", str, len, idx);
-        minim_shutdown(1);
-    }
+    if (idx >= len)
+        string_out_of_bounds_exn("string-ref", str, idx);
 
     return make_char((int) str[idx]);
 }
@@ -127,11 +132,8 @@ minim_object *string_set_proc(minim_object *args) {
     c = minim_char(minim_car(minim_cddr(args)));
     len = strlen(str);
 
-    if (idx >= len) {
-        fprintf(stderr, "string-set!: index out of bounds\n");
-        fprintf(stderr, " string: %s, length: %ld, index %ld\n", str, len, idx);
-        minim_shutdown(1);
-    }
+    if (idx >= len)
+        string_out_of_bounds_exn("string-set!", str, idx);
 
     str[idx] = c;
     return minim_void;

--- a/src/boot/c/symbol.c
+++ b/src/boot/c/symbol.c
@@ -200,7 +200,7 @@ minim_object *make_symbol(const char *s) {
 //  Primitives
 //
 
-minim_object *is_symbol_proc(minim_object *args) {
+minim_object *is_symbol_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_symbol(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_symbol(args[0]) ? minim_true : minim_false;
 }

--- a/src/boot/c/symbol.c
+++ b/src/boot/c/symbol.c
@@ -97,8 +97,7 @@ static uint32_t hash_bytes(const void* data, size_t len) {
     return hash;
 }
 
-static void intern_table_resize(intern_table *itab)
-{
+static void intern_table_resize(intern_table *itab) {
     intern_table_bucket **new_buckets;
     size_t *new_alloc_ptr = ++itab->alloc_ptr;
     size_t new_alloc = *new_alloc_ptr;
@@ -109,10 +108,8 @@ static void intern_table_resize(intern_table *itab)
         new_buckets[i] = NULL;
 
     // move entries to new buckets
-    for (size_t i = 0; i < itab->alloc; ++i)
-    {
-        for (intern_table_bucket *b = itab->buckets[i]; b; b = b->next)
-        {
+    for (size_t i = 0; i < itab->alloc; ++i) {
+        for (intern_table_bucket *b = itab->buckets[i]; b; b = b->next) {
             intern_table_bucket *nb;
             size_t n, h, idx;
 
@@ -128,10 +125,8 @@ static void intern_table_resize(intern_table *itab)
     itab->alloc = new_alloc;
 }
 
-static void intern_table_insert(intern_table *itab, size_t idx, minim_object *sym)
-{
+static void intern_table_insert(intern_table *itab, size_t idx, minim_object *sym) {
     intern_table_bucket *b;
-    
     new_bucket(b, sym, itab->buckets[idx]);
     ++itab->size;
 }
@@ -145,8 +140,7 @@ intern_table *make_intern_table() {
     return itab;
 }
 
-minim_object *intern_symbol(intern_table *itab, const char *sym)
-{
+minim_object *intern_symbol(intern_table *itab, const char *sym) {
     intern_table_bucket *b;
     minim_object *obj;
     size_t n = strlen(sym);
@@ -155,17 +149,14 @@ minim_object *intern_symbol(intern_table *itab, const char *sym)
     char *isym;
 
     b = itab->buckets[idx];
-    while (b != NULL)
-    {
+    while (b != NULL) {
         isym = minim_symbol(b->sym);
         if (isym == sym)
             return b->sym;
 
-        if (strlen(isym) == n)
-        {
+        if (strlen(isym) == n) {
             size_t i;
-            for (i = 0; i < n; ++i)
-            {
+            for (i = 0; i < n; ++i) {
                 if (isym[i] != sym[i])
                     break;
             }

--- a/src/boot/c/syntax.c
+++ b/src/boot/c/syntax.c
@@ -59,7 +59,7 @@ minim_object *to_syntax(minim_object *o) {
 
     default:
         fprintf(stderr, "datum->syntax: cannot convert to syntax");
-        exit(1);
+        minim_shutdown(1);
     }
 }
 
@@ -142,7 +142,7 @@ minim_object *syntax_error_proc(minim_object *args) {
         fprintf(stderr, "\n");
     }
 
-    exit(1);
+    minim_shutdown(1);
 }
 
 minim_object *syntax_e_proc(minim_object *args) {

--- a/src/boot/c/syntax.c
+++ b/src/boot/c/syntax.c
@@ -99,19 +99,19 @@ static minim_object *syntax_to_list(minim_object *head, minim_object *it) {
 //  Primitives
 //
 
-minim_object *is_syntax_proc(minim_object *args) {
+minim_object *is_syntax_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return minim_is_syntax(minim_car(args)) ? minim_true : minim_false;
+    return minim_is_syntax(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *syntax_error_proc(minim_object *args) {
+minim_object *syntax_error_proc(int argc, minim_object **args) {
     // (-> (or #f symbol) string any)
     // (-> (or #f symbol) string syntax any)
     // (-> (or #f symbol) string syntax syntaxs any)
     minim_object *what, *why, *where, *sub;
 
-    what = minim_car(args);
-    why = minim_cadr(args);
+    what = args[0];
+    why = args[1];
     if (!minim_is_false(what) && !minim_is_symbol(what))
         bad_type_exn("syntax-error", "symbol?", what);
     if (!minim_is_string(why))
@@ -123,12 +123,12 @@ minim_object *syntax_error_proc(minim_object *args) {
         fprintf(stderr, "%s: %s\n", minim_symbol(what), minim_string(why));
 
     if (!minim_is_null(minim_cddr(args))) {
-        where = minim_car(minim_cddr(args));
+        where = args[2];
         if (!minim_is_syntax(where))
             bad_type_exn("syntax-error", "syntax?", where);
 
         if (!minim_is_null(minim_cdr(minim_cddr(args)))) {
-            sub = minim_cadr(minim_cddr(args));
+            sub = args[3];
             if (!minim_is_syntax(sub))
                 bad_type_exn("syntax-error", "syntax?", sub);
 
@@ -145,30 +145,30 @@ minim_object *syntax_error_proc(minim_object *args) {
     minim_shutdown(1);
 }
 
-minim_object *syntax_e_proc(minim_object *args) {
+minim_object *syntax_e_proc(int argc, minim_object **args) {
     // (-> syntax any)
-    if (!minim_is_syntax(minim_car(args)))
-        bad_type_exn("syntax-e", "syntax?", minim_car(args));
-    return minim_syntax_e(minim_car(args));
+    if (!minim_is_syntax(args[0]))
+        bad_type_exn("syntax-e", "syntax?", args[0]);
+    return minim_syntax_e(args[0]);
 }
 
-minim_object *syntax_loc_proc(minim_object *args) {
+minim_object *syntax_loc_proc(int argc, minim_object **args) {
     // (-> syntax any)
-    if (!minim_is_syntax(minim_car(args)))
-        bad_type_exn("syntax-loc", "syntax?", minim_car(args));
-    return minim_syntax_loc(minim_car(args));
+    if (!minim_is_syntax(args[0]))
+        bad_type_exn("syntax-loc", "syntax?", args[0]);
+    return minim_syntax_loc(args[0]);
 }
 
-minim_object *to_syntax_proc(minim_object *args) {
+minim_object *to_syntax_proc(int argc, minim_object **args) {
     // (-> any syntax)
-    return to_syntax(minim_car(args));
+    return to_syntax(args[0]);
 }
 
-minim_object *syntax_to_list_proc(minim_object *args) {
+minim_object *syntax_to_list_proc(int argc, minim_object **args) {
     // (-> syntax (or #f list))
     minim_object *stx, *lst;
     
-    stx = minim_car(args);
+    stx = args[0];
     if (!minim_is_syntax(stx))
         bad_type_exn("syntax->list", "syntax?", stx);
 
@@ -181,32 +181,32 @@ minim_object *syntax_to_list_proc(minim_object *args) {
         return syntax_to_list(lst, lst);
 }
 
-minim_object *is_pattern_var_proc(minim_object *args) {
-    return minim_is_pattern_var(minim_car(args)) ? minim_true : minim_false;
+minim_object *is_pattern_var_proc(int argc, minim_object **args) {
+    return minim_is_pattern_var(args[0]) ? minim_true : minim_false;
 }
 
-minim_object *make_pattern_var_proc(minim_object *args) {
+minim_object *make_pattern_var_proc(int argc, minim_object **args) {
     // (-> any non-negative-integer? pattern-var?)
     minim_object *value, *depth;
     
-    value = minim_car(args);
-    depth = minim_cadr(args);
+    value = args[0];
+    depth = args[1];
     if (!minim_is_fixnum(depth) || minim_fixnum(depth) < 0)
         bad_type_exn("make-pattern-var", "non-negative-integer?", depth);
     return make_pattern_var(value, depth);
 }
 
-minim_object *pattern_var_value_proc(minim_object *args) {
+minim_object *pattern_var_value_proc(int argc, minim_object **args) {
     // (-> pattern-var? any)
-    minim_object *var = minim_car(args);
+    minim_object *var = args[0];
     if (!minim_is_pattern_var(var))
         bad_type_exn("pattern-variable-value", "pattern-variable?", var);
     return minim_pattern_var_value(var);   
 }
 
-minim_object *pattern_var_depth_proc(minim_object *args) {
+minim_object *pattern_var_depth_proc(int argc, minim_object **args) {
     // (-> pattern-var? any)
-    minim_object *var = minim_car(args);
+    minim_object *var = args[0];
     if (!minim_is_pattern_var(var))
         bad_type_exn("pattern-variable-depth", "pattern-variable?", var);
     return minim_pattern_var_depth(var);   

--- a/src/boot/c/system.c
+++ b/src/boot/c/system.c
@@ -101,25 +101,26 @@ void minim_shutdown(int code) {
 //  Primitives
 //
 
-minim_object *load_proc(minim_object *args) {
+minim_object *load_proc(int argc, minim_object **args) {
     // (-> string any)
-    if (!minim_is_string(minim_car(args)))
-        bad_type_exn("load", "string?", minim_car(args));
-    return load_file(minim_string(minim_car(args)));
+    if (!minim_is_string(args[0]))
+        bad_type_exn("load", "string?", args[0]);
+    return load_file(minim_string(args[0]));
 }
 
-minim_object *error_proc(minim_object *args) {
+minim_object *error_proc(int argc, minim_object **args) {
     // (-> (or #f string symbol)
     //     string?
     //     any ...
     //     any)
-    minim_object *who, *message, *reasons;
+    minim_object *who, *message;
+    int i;
 
-    who = minim_car(args);
+    who = args[0];
     if (!minim_is_false(who) && !minim_is_symbol(who) && !minim_is_string(who))
         bad_type_exn("error", "(or #f string? symbol?)", who);
 
-    message = minim_cadr(args);
+    message = args[1];
     if (!minim_is_string(message))
         bad_type_exn("error", "string?", message);
     
@@ -132,33 +133,31 @@ minim_object *error_proc(minim_object *args) {
     write_object2(stderr, message, 1, 1);
     fprintf(stderr, "\n");
 
-    reasons = minim_cddr(args);
-    while (!minim_is_null(reasons)) {
+    for (i = 2; i < argc; ++i) {
         fprintf(stderr, " ");
-        write_object2(stderr, minim_car(reasons), 1, 1);
+        write_object2(stderr, args[i], 1, 1);
         fprintf(stderr, "\n");
-        reasons = minim_cdr(reasons);
     }
 
     minim_shutdown(1);
 }
 
-minim_object *exit_proc(minim_object *args) {
+minim_object *exit_proc(int argc, minim_object **args) {
     // (-> any)
     minim_shutdown(0);
 }
 
-minim_object *current_directory_proc(minim_object *args) {
+minim_object *current_directory_proc(int argc, minim_object **args) {
     // (-> string)
     // (-> string void)
     minim_object *path;
 
-    if (minim_is_null(args)) {
+    if (argc == 0) {
         // getter
         return current_directory(current_thread());
     } else {
         // setter
-        path = minim_car(args);
+        path = args[0];
         if (!minim_is_string(path))
             bad_type_exn("current-directory", "string?", path);
         

--- a/src/boot/c/vector.c
+++ b/src/boot/c/vector.c
@@ -32,72 +32,65 @@ static void vector_out_of_bounds_exn(const char *name, minim_object *v, long idx
 //  Primitives
 //
 
-minim_object *is_vector_proc(minim_object *args) {
+minim_object *is_vector_proc(int argc, minim_object **args) {
     // (-> any boolean)
-    return (minim_is_vector(minim_car(args)) ? minim_true : minim_false);
+    return (minim_is_vector(args[0]) ? minim_true : minim_false);
 }
 
-minim_object *make_vector_proc(minim_object *args) {
+minim_object *make_vector_proc(int argc, minim_object **args) {
     // (-> non-negative-integer vector)
     // (-> non-negative-integer any vector)
     minim_object *init;
     long len;
 
-    if (!minim_is_fixnum(minim_car(args)) || minim_fixnum(minim_car(args)) < 0)
-        bad_type_exn("make-vector", "non-negative-integer?", minim_car(args));
-    len = minim_fixnum(minim_car(args));
+    if (!minim_is_fixnum(args[0]) || minim_fixnum(args[0]) < 0)
+        bad_type_exn("make-vector", "non-negative-integer?", args[0]);
+    len = minim_fixnum(args[0]);
 
     if (len == 0) {
         // special case:
         return minim_empty_vec;
     }
 
-    if (minim_is_null(minim_cdr(args))) {
+    if (argc == 1) {
         // 1st case
         init = make_fixnum(0);
     } else {
         // 2nd case
-        init = minim_cadr(args);
+        init = args[1];
     }
 
     return make_vector(len, init);
 }
 
-minim_object *vector_proc(minim_object *args) {
+minim_object *vector_proc(int argc, minim_object **args) {
     // (-> any ... vector)
-    minim_object *v, *it;
-    long len, i;
+    minim_object *v;
     
-    len = list_length(args);
-    if (len == 0) {
-        return minim_empty_vec;
-    } else {
-        v = make_vector(len, NULL);
-        for (i = 0, it = args; i < len; ++i, it = minim_cdr(it))
-            minim_vector_ref(v, i) = minim_car(it);
-        return v;
-    }
+    v = make_vector(argc, NULL);
+    memcpy(minim_vector_arr(v), args, argc * sizeof(minim_object*));
+    return v;
 }
 
-minim_object *vector_length_proc(minim_object *args) {
+minim_object *vector_length_proc(int argc, minim_object **args) {
     // (-> vector non-negative-integer?)
     minim_object *v;
     
-    v = minim_car(args);
+    v = args[0];
     if (!minim_is_vector(v))
         bad_type_exn("vector-length", "vector?", v);
     return make_fixnum(minim_vector_len(v));
 }
 
-minim_object *vector_ref_proc(minim_object *args) {
+minim_object *vector_ref_proc(int argc, minim_object **args) {
     // (-> vector non-negative-integer? any)
     minim_object *v, *idx;
     
-    v = minim_car(args);
+    v = args[0];
     if (!minim_is_vector(v))
         bad_type_exn("vector-ref", "vector?", v);
 
-    idx = minim_cadr(args);
+    idx = args[1];
     if (!minim_is_fixnum(idx) || minim_fixnum(idx) < 0)
         bad_type_exn("vector-ref", "non-negative-integer?", idx);
     if (minim_fixnum(idx) >= minim_vector_len(v))
@@ -106,15 +99,15 @@ minim_object *vector_ref_proc(minim_object *args) {
     return minim_vector_ref(v, minim_fixnum(idx));
 }
 
-minim_object *vector_set_proc(minim_object *args) {
+minim_object *vector_set_proc(int argc, minim_object **args) {
     // (-> vector non-negative-integer? any void)
     minim_object *v, *idx;
     
-    v = minim_car(args);
+    v = args[0];
     if (!minim_is_vector(v))
         bad_type_exn("vector-set!", "vector?", v);
 
-    idx = minim_cadr(args);
+    idx = args[1];
     if (!minim_is_fixnum(idx) || minim_fixnum(idx) < 0)
         bad_type_exn("vector-set!", "non-negative-integer?", idx);
     if (minim_fixnum(idx) >= minim_vector_len(v))
@@ -124,28 +117,28 @@ minim_object *vector_set_proc(minim_object *args) {
     return minim_void;
 }
 
-minim_object *vector_fill_proc(minim_object *args) {
+minim_object *vector_fill_proc(int argc, minim_object **args) {
     // (-> vector any void)
     minim_object *v, *o;
     long i;
 
-    v = minim_car(args);
+    v = args[0];
     if (!minim_is_vector(v))
         bad_type_exn("vector-fill!", "vector?", v);
 
-    o = minim_cadr(args);
+    o = args[1];
     for (i = 0; i < minim_vector_len(v); ++i)
         minim_vector_ref(v, i) = o;
 
     return minim_void;
 }
 
-minim_object *vector_to_list_proc(minim_object *args) {
+minim_object *vector_to_list_proc(int argc, minim_object **args) {
     // (-> vector list)
     minim_object *v, *lst;
     long i;
     
-    v = minim_car(args);
+    v = args[0];
     if (!minim_is_vector(v))
         bad_type_exn("vector->list", "vector?", v);
 
@@ -156,12 +149,12 @@ minim_object *vector_to_list_proc(minim_object *args) {
     return lst;
 }
 
-minim_object *list_to_vector_proc(minim_object *args) {
+minim_object *list_to_vector_proc(int argc, minim_object **args) {
     // (-> list vector)
     minim_object *v, *lst, *it;
     long i;
     
-    lst = minim_car(args);
+    lst = args[0];
     if (!is_list(lst))
         bad_type_exn("list->vector", "list?", lst);
 

--- a/src/boot/c/vector.c
+++ b/src/boot/c/vector.c
@@ -113,7 +113,7 @@ minim_object *vector_set_proc(int argc, minim_object **args) {
     if (minim_fixnum(idx) >= minim_vector_len(v))
         vector_out_of_bounds_exn("vector-set!", v, minim_fixnum(idx));
 
-    minim_vector_ref(v, minim_fixnum(idx)) = minim_car(minim_cddr(args));
+    minim_vector_ref(v, minim_fixnum(idx)) = args[2];
     return minim_void;
 }
 

--- a/src/boot/c/vector.c
+++ b/src/boot/c/vector.c
@@ -25,7 +25,7 @@ static void vector_out_of_bounds_exn(const char *name, minim_object *v, long idx
     fprintf(stderr, "%s, index out of bounds\n", name);
     fprintf(stderr, " length: %ld\n", minim_vector_len(v));
     fprintf(stderr, " index:  %ld\n", idx);
-    exit(1);
+    minim_shutdown(1);
 }
 
 //

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -13,6 +13,15 @@
 
 #include "../gc/gc.h"
 
+// Config
+
+#if defined (__GNUC__)
+#define MINIM_GCC     1
+#define NORETURN    __attribute__ ((noreturn))
+#else
+#error "compiler not supported"
+#endif
+
 // Constants
 
 #define MINIM_VERSION      "0.4.0"
@@ -437,6 +446,8 @@ char* get_current_dir();
 void set_current_dir(const char *str);
 
 minim_object *load_file(const char *fname);
+
+NORETURN void minim_shutdown(int code);
 
 // Exceptions
 

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -134,7 +134,7 @@ typedef struct {
 typedef struct {
     minim_object_type type;
     struct proc_arity arity;
-    minim_object *(*fn)(minim_object *);
+    minim_object *(*fn)(int, minim_object **);
     char *name;
 } minim_prim_proc_object;
 
@@ -302,7 +302,7 @@ extern minim_object *quote_syntax_symbol;
 
 // Typedefs
 
-typedef minim_object *(*minim_prim_proc_t)(minim_object *);
+typedef minim_object *(*minim_prim_proc_t)(int argc, minim_object **);
 
 // Constructors
 
@@ -478,7 +478,7 @@ NORETURN void uncallable_prim_exn(const char *name);
 // Primitives
 
 #define DEFINE_PRIM_PROC(name) \
-    minim_object *name ## _proc(minim_object *);
+    minim_object *name ## _proc(int, minim_object **);
 
 // special objects
 DEFINE_PRIM_PROC(is_null);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -451,8 +451,10 @@ NORETURN void minim_shutdown(int code);
 
 // Exceptions
 
-void bad_syntax_exn(minim_object *expr);
-void bad_type_exn(const char *name, const char *type, minim_object *x);
+NORETURN void bad_syntax_exn(minim_object *expr);
+NORETURN void bad_type_exn(const char *name, const char *type, minim_object *x);
+NORETURN void result_arity_exn(short expected, short actual);
+NORETURN void uncallable_prim_exn(const char *name);
 
 // Primitives
 

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -327,13 +327,8 @@ minim_object *make_syntax(minim_object *e, minim_object *loc);
 int minim_is_eq(minim_object *a, minim_object *b);
 int minim_is_equal(minim_object *a, minim_object *b);
 
-minim_object *call_with_args(minim_object *proc,
-                             minim_object *args,
-                             minim_object *env);
-
-minim_object *call_with_values(minim_object *producer,
-                               minim_object *consumer,
-                               minim_object *env);
+minim_object *call_with_args(minim_object *proc, minim_object *env);
+minim_object *call_with_values(minim_object *producer, minim_object *consumer, minim_object *env);
 
 int is_list(minim_object *x);
 long list_length(minim_object *xs);
@@ -364,6 +359,13 @@ typedef struct {
     long call_args_count, saved_args_count;
     long call_args_size, saved_args_size;
 } interp_rt;
+
+void push_saved_arg(minim_object *arg);
+void push_call_arg(minim_object *arg);
+void prepare_call_args(long count);
+void clear_call_args();
+
+void assert_no_call_args();
 
 // Environments
 

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -335,10 +335,10 @@ long list_length(minim_object *xs);
 minim_object *make_assoc(minim_object *xs, minim_object *ys);
 minim_object *copy_list(minim_object *xs);
 
-minim_object *for_each(minim_object *proc, minim_object *lsts, minim_object *env);
-minim_object *map_list(minim_object *proc, minim_object *lst, minim_object *env);
-minim_object *andmap(minim_object *proc, minim_object *lst, minim_object *env);
-minim_object *ormap(minim_object *proc, minim_object *lst, minim_object *env);
+minim_object *for_each(minim_object *proc, int argc, minim_object **args, minim_object *env);
+minim_object *map_list(minim_object *proc, int argc, minim_object **args, minim_object *env);
+minim_object *andmap(minim_object *proc, int argc, minim_object **args, minim_object *env);
+minim_object *ormap(minim_object *proc, int argc, minim_object **args, minim_object *env);
 
 minim_object *strip_syntax(minim_object *o);
 minim_object *to_syntax(minim_object *o);

--- a/src/boot/minim.h
+++ b/src/boot/minim.h
@@ -354,7 +354,16 @@ void write_object2(FILE *out, minim_object *o, int quote, int display);
 
 // Interpreter
 
+#define CALL_ARGS_DEFAULT       10
+#define SAVED_ARGS_DEFAULT      10
+
 minim_object *eval_expr(minim_object *expr, minim_object *env);
+
+typedef struct {
+    minim_object **call_args, **saved_args;
+    long call_args_count, saved_args_count;
+    long call_args_size, saved_args_size;
+} interp_rt;
 
 // Environments
 
@@ -429,6 +438,7 @@ void resize_values_buffer(minim_thread *th, int size);
 // Globals
 
 typedef struct minim_globals {
+    interp_rt irt;
     minim_thread *current_thread;
     intern_table *symbols;
 } minim_globals;
@@ -438,6 +448,13 @@ extern size_t bucket_sizes[];
 
 #define current_thread()    (globals->current_thread)
 #define intern(s)           (intern_symbol(globals->symbols, s))
+
+#define irt_call_args               (globals->irt.call_args)
+#define irt_saved_args              (globals->irt.saved_args)
+#define irt_call_args_count         (globals->irt.call_args_count)
+#define irt_saved_args_count        (globals->irt.saved_args_count)
+#define irt_call_args_size          (globals->irt.call_args_size)
+#define irt_saved_args_size         (globals->irt.saved_args_size)
 
 // System
 

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -488,6 +488,21 @@ int test_syntax() {
     return passed;
 }
 
+int test_apply() {
+    passed = 1;
+
+    check_equal("(apply + '())", "0");
+    check_equal("(apply + 1 '())", "1");
+    check_equal("(apply + 1 2 3 '())", "6");
+    check_equal("(apply + 1 '(2 3))", "6");
+    check_equal("(apply + '(1 2 3))", "6");
+
+    check_equal("(apply apply + '(()))", "0");
+    check_equal("(apply apply + '(1 2 (3 4)))", "10");
+    
+    return passed;
+}
+
 int test_if() {
     passed = 1;
 
@@ -855,6 +870,8 @@ void run_tests() {
     log_test("vector", test_vector);
     log_test("integer", test_integer);
     log_test("hashtable", test_hashtable);
+
+    log_test("apply", test_apply);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR cleanups the boot interpreter and switches the evaluator to an argument stack for saving arguments for future computations rather than allocating an argument list.