### PR TITLE
Sets

### DIFF
--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -646,11 +646,6 @@ int test_box() {
                   "(set-box! b 0)"
                   "(unbox b))",
                 "0");
-    
-    check_equal("(equal? (box 1) (box 1))", "#t");
-    check_equal("(equal? (box 1) (box 2))", "#f");
-    check_equal("(equal? (box '(1 2)) (box '(1 2)))", "#t");
-    check_equal("(equal? (box '(1 2)) (box '(3 4)))", "#f");
 
     return passed;
 }

--- a/src/boot/test/test-prims.c
+++ b/src/boot/test/test-prims.c
@@ -646,6 +646,11 @@ int test_box() {
                   "(set-box! b 0)"
                   "(unbox b))",
                 "0");
+    
+    check_equal("(equal? (box 1) (box 1))", "#t");
+    check_equal("(equal? (box 1) (box 2))", "#f");
+    check_equal("(equal? (box '(1 2)) (box '(1 2)))", "#t");
+    check_equal("(equal? (box '(1 2)) (box '(3 4)))", "#f");
 
     return passed;
 }

--- a/src/core/c/hashtable.c
+++ b/src/core/c/hashtable.c
@@ -162,10 +162,15 @@ static size_t equal_hash2(minim_object *o, size_t hash) {
         return hash;
     case MINIM_BOX_TYPE:
         return equal_hash2(minim_box_contents(o), hash);
-    // case MINIM_RECORD_TYPE:
-    //     for (i = 0; i < minim_record_count(o); ++i)
-    //         hash = equal_hash2(minim_record_ref(o, i), hash);
-    //     return hash;
+    case MINIM_RECORD_TYPE:
+        // See note in `minim_is_equal` about record equality
+        if (is_record_rtd(o)) {
+            return eq_hash2(o, hash);
+        } else {
+            for (i = 0; i < minim_record_count(o); ++i)
+                hash = equal_hash2(minim_record_ref(o, i), hash);
+        }
+        return hash;
     default:
         return eq_hash2(o, hash);
     }

--- a/src/core/c/hashtable.c
+++ b/src/core/c/hashtable.c
@@ -160,6 +160,12 @@ static size_t equal_hash2(minim_object *o, size_t hash) {
             }
         }
         return hash;
+    case MINIM_BOX_TYPE:
+        return equal_hash2(minim_box_contents(o), hash);
+    // case MINIM_RECORD_TYPE:
+    //     for (i = 0; i < minim_record_count(o); ++i)
+    //         hash = equal_hash2(minim_record_ref(o, i), hash);
+    //     return hash;
     default:
         return eq_hash2(o, hash);
     }

--- a/src/core/c/object.c
+++ b/src/core/c/object.c
@@ -77,6 +77,9 @@ int minim_is_equal(minim_object *a, minim_object *b) {
         }
 
         return 1;
+    
+    case MINIM_BOX_TYPE:
+        return minim_is_equal(minim_box_contents(a), minim_box_contents(b));
 
     case MINIM_HASHTABLE_TYPE:
         return hashtable_is_equal(a, b);

--- a/src/core/c/object.c
+++ b/src/core/c/object.c
@@ -79,10 +79,7 @@ int minim_is_equal(minim_object *a, minim_object *b) {
         return 1;
 
     case MINIM_HASHTABLE_TYPE:
-        if (minim_hashtable_size(a) != minim_hashtable_size(b))
-            return 0;
-
-        return 0;
+        return hashtable_is_equal(a, b);
 
     default:
         return 0;

--- a/src/core/c/object.c
+++ b/src/core/c/object.c
@@ -84,6 +84,42 @@ int minim_is_equal(minim_object *a, minim_object *b) {
     case MINIM_HASHTABLE_TYPE:
         return hashtable_is_equal(a, b);
 
+    case MINIM_RECORD_TYPE:
+        // TODO: Other Schemes make records return #f by default for equal?
+        // while providing a way to specifiy an equality procedure for
+        // records of the same type.
+        // In this case, equal? would possibly need access to the
+        // current environment. It's possible that setting the equality
+        // procedure using anything other than a closure should throw
+        // an error.
+        //
+        // Minim implements record equality in the following way:
+        // Any record type descriptor is only `equal?` to itself
+        // Two record values are equal if and only if
+        //  (i)  they share record types
+        //  (ii) each of their fields are `equal?`
+        //
+        if (is_record_rtd(a)) {
+            if (!is_record_rtd(b))
+                return 0;
+
+            // this should use eq? based comparisons
+            return minim_is_eq(a, b);
+        } else {
+            if (!is_record_value(b))
+                return 0;
+
+            if (minim_record_rtd(a) != minim_record_rtd(b))
+                return 0;
+            
+            for (i = 0; i < minim_record_count(a); ++i) {
+                if (!minim_is_equal(minim_record_ref(a, i), minim_record_ref(b, i)))
+                    return 0;
+            }
+
+            return 1;
+        }
+
     default:
         return 0;
     }

--- a/src/core/c/record.c
+++ b/src/core/c/record.c
@@ -26,12 +26,12 @@ static int is_true_record(minim_object *o) {
 }
 
 // Returns 1 when `o` is a record value, and 0 otherwise.
-static int is_record_value(minim_object *o) {
+int is_record_value(minim_object *o) {
     return minim_is_record(o) && minim_record_rtd(o) != minim_base_rtd;
 }
 
 // Returns 1 when `o` is a record type descriptor, and 0 otherwise.
-static int is_record_rtd(minim_object *o) {
+int is_record_rtd(minim_object *o) {
     return minim_is_record(o) && minim_record_rtd(o) == minim_base_rtd;
 }
 

--- a/src/core/minim.h
+++ b/src/core/minim.h
@@ -511,6 +511,9 @@ minim_object *make_rest_argument(minim_object *args[], short argc);
 #define record_is_opaque(o)     (record_rtd_opaque(minim_record_rtd(o)) == minim_true)
 #define record_is_sealed(o)     (record_rtd_sealed(minim_record_rtd(o)) == minim_true)
 
+int is_record_value(minim_object *o);
+int is_record_rtd(minim_object *o);
+
 // Symbols
 
 typedef struct intern_table_bucket {

--- a/src/core/minim.h
+++ b/src/core/minim.h
@@ -529,6 +529,7 @@ minim_object *intern_symbol(intern_table *itab, const char *sym);
 
 // Hashtables
 
+int hashtable_is_equal(minim_object *h1, minim_object *h2);
 int hashtable_set(minim_object *ht, minim_object *k, minim_object *v);
 minim_object *hashtable_find(minim_object *ht, minim_object *k);
 minim_object *hashtable_keys(minim_object *ht);

--- a/src/library/base.min
+++ b/src/library/base.min
@@ -6,10 +6,12 @@
         "private/path.min"
         "private/pre-base.min"
         "private/record.min"
+        "private/set.min"
         "private/string.min")
 
 (export (all "private/list.min")
         (all "private/path.min")
         (all "private/pre-base.min")
         (all "private/record.min")
+        (all "private/set.min")
         (all "private/string.min"))

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -24,7 +24,8 @@
 
         set-union
         set-intersect
-        set-subtract)
+        set-subtract
+        set-symmetric-difference)
 
 ;;
 ;;  Definition
@@ -202,4 +203,23 @@
            (when (set-member? st x)
              (set-remove! diff x)))
          diff)
+       (loop (cdr sts))])))
+
+(define (set-symmetric-difference st0 . sts)
+  (for-each (lambda (s)
+              (unless (set? s)
+                (error 'set-symmetric-difference "expected a set" s)))
+            (cons st0 sts))
+  (define diff (set-copy st0))
+  (let loop ([sts sts])
+    (cond
+      [(null? sts) diff]
+      [else
+       (define st (car sts))
+       (set-for-each
+         (lambda (x)
+           (if (set-member? diff x)
+               (set-remove! diff x)
+               (set-add! diff x)))
+         st)
        (loop (cdr sts))])))

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -6,10 +6,14 @@
 (export make-set
         set?
         set-member?
-        set-add!
-        set-remove!
+        set-copy
+        set-empty?
         set-count
         set->list
+
+        set-add!
+        set-remove!
+        set-clear!
 
         set-map
         set-for-each
@@ -41,10 +45,22 @@
     (error 'set-member? "expected a set" s))
   (hashtable-contains? (set-store s) v))
 
+(define (set-empty? st)
+  (unless (set? st)
+    (error 'set-empty? "expected a set" st))
+  (= (hashtable-size (set-store st)) 0))
+
 (define (set-count s)
   (unless (set? s)
     (error 'set-count "expected a set" s))
   (hashtable-size (set-store s)))
+
+(define (set-copy st)
+  (unless (set? st)
+    (error 'set-copy "expected a set" st))
+  (define cp (make-set))
+  (for-each (lambda (x) (set-add! cp x)) (set->list st))
+  cp)
 
 (define (set-add! s v)
   (unless (set? s)
@@ -55,6 +71,11 @@
   (unless (set? s)
     (error 'set-remove! "expected a set" s))
   (hashtable-delete! (set-store s) v))
+
+(define (set-clear! st)
+  (unless (set? st)
+    (error 'set-clear! "expected a set" st))
+  (hashtable-clear! (set-store st)))
 
 (define (set->list s)
   (unless (set? s)

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -11,6 +11,9 @@
         set-count
         set->list
 
+        set-map
+        set-for-each
+
         set-union
         set-intersect)
 
@@ -57,6 +60,20 @@
   (unless (set? s)
     (error 'set->list "expected a set" s))
   (hashtable-keys (set-store s)))
+
+;;
+;;  Set iteration
+;;
+
+(define (set-map proc st)
+  (unless (set? st)
+    (error 'set-map "expected a set" st))
+  (map proc (set->list st)))
+
+(define (set-for-each proc st)
+  (unless (set? st)
+    (error 'set-for-each "expected a set" st))
+  (for-each proc (set->list st)))
 
 ;;
 ;;  Set/Set operations

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -1,0 +1,55 @@
+;;;
+;;; Sets
+;;;
+
+(import "pre-base.min" "list.min" "record.min")
+(export make-set set?
+        set-contains?
+        set-add!
+        set-remove!
+        set-count
+        set->list)
+
+;;
+;;  Definition
+;;
+
+(define-record-type set
+  (opaque #t)
+  (sealed #t)
+  (fields (mutable store))
+  (protocol
+    (lambda (p)
+      (lambda xs
+        (define h (make-hashtable))
+        (for-each (lambda (x) (hashtable-set! h x '())) xs)
+        (p h)))))
+
+;;
+;;  Procedures
+;;
+
+(define (set-contains? s v)
+  (unless (set? s)
+    (error 'set-contains? "expected a set" s))
+  (hashtable-contains? (set-store s) v))
+
+(define (set-count s)
+  (unless (set? s)
+    (error 'set-count "expected a set" s))
+  (hashtable-size (set-store s)))
+
+(define (set-add! s v)
+  (unless (set? s)
+    (error 'set-add! "expected a set" s))
+  (hashtable-set! (set-store s) v '()))
+
+(define (set-remove! s v)
+  (unless (set? s)
+    (error 'set-remove! "expected a set" s))
+  (hashtable-delete! (set-store s) v '()))
+
+(define (set->list s)
+  (unless (set? s)
+    (error 'set->list "expected a set" s))
+  (hashtable-keys (set-store s)))

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -23,7 +23,8 @@
         set-for-each
 
         set-union
-        set-intersect)
+        set-intersect
+        set-subtract)
 
 ;;
 ;;  Definition
@@ -184,3 +185,21 @@
                         (set-add! i* x)))
                     (set->list i))
           (loop (cdr ss) i*)]))]))
+
+(define (set-subtract st0 . sts)
+  (for-each (lambda (s)
+              (unless (set? s)
+                (error 'set-subtract "expected a set" s)))
+            (cons st0 sts))
+  (define diff (set-copy st0))
+  (let loop ([sts sts])
+    (cond
+      [(null? sts) diff]
+      [else
+       (define st (car sts))
+       (set-for-each
+         (lambda (x)
+           (when (set-member? st x)
+             (set-remove! diff x)))
+         diff)
+       (loop (cdr sts))])))

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -3,14 +3,16 @@
 ;;;
 
 (import "pre-base.min" "list.min" "record.min")
-(export make-set set?
+(export make-set
+        set?
         set-member?
         set-add!
         set-remove!
         set-count
-        set->list)
+        set->list
 
-        ; set-union)
+        set-union
+        set-intersect)
 
 ;;
 ;;  Definition
@@ -60,20 +62,54 @@
 ;;  Set/Set operations
 ;;
 
-; (define (set-union . ss)
-;   (define u (make-set))
-;   (for-each (lambda (s)
-;               (unless (set? s)
-;                 (error 'set-union "expected a set" s))
-;               (for-each (lambda (x) (set-add! u x)) (set->list s)))
-;             ss)
-;   u)
+(define (set-union . ss)
+  (for-each (lambda (s)
+              (unless (set? s)
+                (error 'set-union "expected a set" s)))
+            ss)
+  (cond
+    [(null? ss)
+     (make-set)]
+    [(null? (cdr ss))
+     (define s (car ss))
+     (define c (make-set))
+     (for-each (lambda (x) (set-add! c x)) (set->list s))
+     c]
+    [else
+     (define u (make-set))
+     (for-each (lambda (s)
+                 (unless (set? s)
+                   (error 'set-union "expected a set" s))
+                 (for-each (lambda (x) (set-add! u x)) (set->list s)))
+               ss)
+     u]))
 
-; (define (set-intersect . ss)
-;   (define u (make-set))
-;   (for-each (lambda (s)
-;               (unless (set? s)
-;                 (error 'set-union "expected a set" s))
-;               (for-each (lambda (x) (set-add! u x)) (set->list s)))
-;             ss)
-;   u)
+(define (set-intersect . ss)
+  (for-each (lambda (s)
+              (unless (set? s)
+                (error 'set-intersect "expected a set" s)))
+            ss)
+  (cond
+    [(null? ss)
+     (make-set)]
+    [(null? (cdr ss))
+     (define s (car ss))
+     (define c (make-set))
+     (for-each (lambda (x) (set-add! c x)) (set->list s))
+     c]
+    [else
+     (define s (car ss))
+     (define i (make-set))
+     (for-each (lambda (x) (set-add! i x)) (set->list s))
+     (let loop ([ss (cdr ss)] [i i])
+       (cond
+         [(null? ss) i]
+         [(= (set-count i) 0) i]
+         [else
+          (define s (car ss))
+          (define i* (make-set))
+          (for-each (lambda (x)
+                      (when (set-member? s x)
+                        (set-add! i* x)))
+                    (set->list i))
+          (loop (cdr ss) i*)]))]))

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -4,11 +4,13 @@
 
 (import "pre-base.min" "list.min" "record.min")
 (export make-set set?
-        set-contains?
+        set-member?
         set-add!
         set-remove!
         set-count
         set->list)
+
+        ; set-union)
 
 ;;
 ;;  Definition
@@ -26,12 +28,12 @@
         (p h)))))
 
 ;;
-;;  Procedures
+;;  Basic operations
 ;;
 
-(define (set-contains? s v)
+(define (set-member? s v)
   (unless (set? s)
-    (error 'set-contains? "expected a set" s))
+    (error 'set-member? "expected a set" s))
   (hashtable-contains? (set-store s) v))
 
 (define (set-count s)
@@ -47,9 +49,31 @@
 (define (set-remove! s v)
   (unless (set? s)
     (error 'set-remove! "expected a set" s))
-  (hashtable-delete! (set-store s) v '()))
+  (hashtable-delete! (set-store s) v))
 
 (define (set->list s)
   (unless (set? s)
     (error 'set->list "expected a set" s))
   (hashtable-keys (set-store s)))
+
+;;
+;;  Set/Set operations
+;;
+
+; (define (set-union . ss)
+;   (define u (make-set))
+;   (for-each (lambda (s)
+;               (unless (set? s)
+;                 (error 'set-union "expected a set" s))
+;               (for-each (lambda (x) (set-add! u x)) (set->list s)))
+;             ss)
+;   u)
+
+; (define (set-intersect . ss)
+;   (define u (make-set))
+;   (for-each (lambda (s)
+;               (unless (set? s)
+;                 (error 'set-union "expected a set" s))
+;               (for-each (lambda (x) (set-add! u x)) (set->list s)))
+;             ss)
+;   u)

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -11,6 +11,10 @@
         set-count
         set->list
 
+        subset?
+        proper-subset?
+        set=?
+
         set-add!
         set-remove!
         set-clear!
@@ -81,6 +85,35 @@
   (unless (set? s)
     (error 'set->list "expected a set" s))
   (hashtable-keys (set-store s)))
+
+;;
+;;  Set comparison
+;;
+
+(define (subset? st st2)
+  (unless (set? st)
+    (error 'subset? "expected a set" st))
+  (unless (set? st2)
+    (error 'subset? "expected a set" st2))
+  (let loop ([elts (set->list st)])
+    (cond
+      [(null? elts) #t]
+      [(set-member? st2 (car elts)) (loop (cdr elts))]
+      [else #f])))
+
+(define (proper-subset? st st2)
+  (unless (set? st)
+    (error 'proper-subset? "expected a set" st))
+  (unless (set? st2)
+    (error 'proper-subset? "expected a set" st2))
+  (and (subset? st st2) (not (subset? st2 st))))
+
+(define (set=? st st2)
+  (unless (set? st)
+    (error 'set=? "expected a set" st))
+  (unless (set? st2)
+    (error 'set=? "expected a set" st2))
+  (and (subset? st st2) (subset? st2 st)))
 
 ;;
 ;;  Set iteration

--- a/test/base/box.min
+++ b/test/base/box.min
@@ -1,0 +1,56 @@
+;;;
+;;; Tests for 'box'
+;;;
+
+(import "../../src/library/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-not-equal? d0 d1)
+  (when (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+; Test `equal?` for boxes
+(let ()
+  (check-equal? (box 1) (box 1))
+  (check-not-equal? (box 1) (box 2))
+  (check-equal? (box '(1 2)) (box '(1 2)))
+  (check-not-equal? (box '(1 2)) (box '(3 4)))
+
+  (void))
+
+; Test `hash?` for boxes
+(let ()
+  (check-equal? (box 1) (box 1))
+  (check-not-equal? (box 1) (box 2))
+  (check-equal? (box '(1 2)) (box '(1 2)))
+  (check-not-equal? (box '(1 2)) (box '(3 4)))
+
+  (void))
+
+; Test `equal-hash` for boxes
+(let ()
+  (check-equal? (equal-hash (box 'a)) (equal-hash (box 'a)))
+  (check-equal? (equal-hash (box 1)) (equal-hash (box 1)))
+  (check-equal? (equal-hash (box '(1 2 3))) (equal-hash (box '(1 2 3))))
+  (check-equal? (equal-hash (box (box 3))) (equal-hash (box (box 3))))
+
+  (void))
+
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/test/base/hashtable.min
+++ b/test/base/hashtable.min
@@ -1,0 +1,60 @@
+;;;
+;;; Tests for 'hashtable'
+;;;
+
+(import "../../src/library/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-not-equal? d0 d1)
+  (when (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+; Test `equal?` for hashtables
+(let ()
+  (define h1 (make-hashtable))
+  (define h2 (make-hashtable))
+
+  (check-equal? h1 h2)
+
+  (hashtable-set! h1 'a 1)
+  (check-not-equal? h1 h2)
+
+  (hashtable-set! h2 'a 1)
+  (check-equal? h1 h2)
+
+  (hashtable-set! h1 'b 2)
+  (hashtable-set! h1 'c 3)
+  (hashtable-set! h2 'b 2)
+  (hashtable-set! h2 'c 3)
+  (check-equal? h1 h2)
+
+  (define keys '(d e f g h i j k l m n o))
+  (enumerate (lambda (k i) (hashtable-set! h1 k i)) keys)
+  (enumerate (lambda (k i) (hashtable-delete! h1 k)) keys)
+  (check-equal? h1 h2)
+
+  (define keys '(d e f g h i j k l m n o))
+  (enumerate (lambda (k i) (hashtable-set! h1 k i)) keys)
+  (enumerate (lambda (k i) (hashtable-set! h2 k i)) keys)
+  (check-equal? h1 h2)
+
+  (void))
+
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/test/base/record.min
+++ b/test/base/record.min
@@ -24,6 +24,15 @@
     (newline)
     (set! num-failed (+ num-failed 1))))
 
+(define (check-not-equal? d0 d1)
+  (when (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
 (define (check-true d)
   (unless d
     (display "[FAIL] expected #t")
@@ -41,7 +50,7 @@
     (set! num-failed (+ num-failed 1))))
 
 ;; Low-level record procedures
-(define (test-0)
+(let ()
   (define point (make-record-type-descriptor 'point #f #f #f #f '#((mutable x) (mutable y) (mutable z))))
   (define make-point (record-constructor point))
   (define point? (record-predicate point))
@@ -78,7 +87,7 @@
 
 
 ;; Basic `define-record-type` test
-(define (test-1)
+(let ()
 
   (define-record-type rec
     (fields
@@ -134,7 +143,7 @@
 
 
 ;; Test inheritance
-(define (test-2)
+(let ()
 
   (define-record-type point
     (fields (mutable x) (mutable y)))
@@ -166,7 +175,8 @@
 
 
 ;; Test protocol
-(define (test-3)
+(let ()
+
   (define count 0)
   (define-record-type (:counting-unit: tick :counting-unit:?)
     (fields step)
@@ -188,7 +198,8 @@
   (void))
 
 ;; Test opacity
-(define (test-4)
+(let ()
+
   (define-record-type a)
 
   (check-false (record-type-opaque? a))
@@ -203,7 +214,8 @@
   (void))
 
 ;; Singleton example
-(define (test-5)
+(let ()
+
   (define nonce-instance #f)
   (define-record-type (:nonce: make-nonce nonce?)
     (opaque #t)
@@ -226,14 +238,39 @@
 
   (void))
 
-;; Run the tests
+;; Test record equality
+(let ()
+  (define-record-type foo
+    (fields a))
 
-(test-0)
-(test-1)
-(test-2)
-(test-3)
-(test-4)
-(test-5)
+  (define f1 (make-foo 1))
+  (define f2 (make-foo 1))
+  (define f3 (make-foo 2))
+
+  (check-equal? f1 f2)
+  (check-not-equal? f1 f3)
+
+  (check-equal? (equal-hash f1) (equal-hash f2))
+  (check-not-equal? (equal-hash f1) (equal-hash f3))
+
+  (define-record-type bar
+    (fields a b))
+
+  (define b1 (make-bar 1 2))
+  (define b2 (make-bar 1 2))
+  (define b3 (make-bar 1 3))
+
+  (check-equal? b1 b2)
+  (check-not-equal? b1 b3)
+
+  (check-equal? (equal-hash b1) (equal-hash b2))
+  (check-not-equal? (equal-hash b1) (equal-hash b3))
+
+  (check-not-equal? foo bar)
+  (check-not-equal? (equal-hash foo) (equal-hash bar))
+
+  (void))
+
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -163,5 +163,36 @@
 
   (void))
 
+;; Test `set-map` and `set-for-each`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+  (define calls 0)
+  (define count 0)
+
+  (define (increment! x)
+    (set! calls (+ calls 1))
+    (set! count (+ count x)))
+
+  (check-equal? (set-map (lambda (x) (* 2 x)) s0) '())
+  (check-equal? (set-map (lambda (x) (* 2 x)) s1) '(4 2))
+  (check-equal? (set-map (lambda (x) (* 2 x)) s2) '(4 2 6))
+
+  (set-for-each increment! s0)
+  (check-equal? calls 0)
+  (check-equal? count 0)
+
+  (set-for-each increment! s1)
+  (check-equal? calls 2)
+  (check-equal? count 3)
+
+  (set-for-each increment! s2)
+  (check-equal? calls 5)
+  (check-equal? count 9)
+
+  (void))
+
+
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -108,7 +108,60 @@
 
   (void))
 
+;; Test `set-union`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 2 3))
+  (define s3 (make-set 4 5 6))
 
+  ; 0 arguments
+  (check-equal? (set->list (set-union)) '())
+
+  ; 1 arguments
+  (check-equal? (set->list (set-union s1)) (set->list s1))
+  (check-equal? (set->list (set-union s2)) (set->list s2))
+  (check-equal? (set->list (set-union s3)) (set->list s3))
+
+  ; 2 arguments
+  (check-equal? (set->list (set-union s0 s1)) (set->list s1))
+  (check-equal? (set->list (set-union s0 s3)) (set->list s3))
+  (check-equal? (set->list (set-union s1 s2)) '(2 1 3))
+  (check-equal? (set->list (set-union s1 s3)) '(2 6 1 5 4))
+
+  ; 3 arguments
+  (check-equal? (set->list (set-union s1 s1 s1)) (set->list s1))
+  (check-equal? (set->list (set-union s1 s2 s3)) '(2 6 1 5 4 3))
+
+  (void))
+
+;; Test `set-intersect`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 2 3))
+  (define s3 (make-set 1 2 3))
+
+  ; 0 arguments
+  (check-equal? (set->list (set-intersect)) '())
+
+  ; 1 arguments
+  (check-equal? (set->list (set-intersect s1)) (set->list s1))
+  (check-equal? (set->list (set-intersect s2)) (set->list s2))
+  (check-equal? (set->list (set-intersect s3)) (set->list s3))
+
+  ; 2 arguments
+  (check-equal? (set->list (set-intersect s3 s3)) (set->list s3))
+  (check-equal? (set->list (set-intersect s0 s1)) '())
+  (check-equal? (set->list (set-intersect s0 s3)) '())
+  (check-equal? (set->list (set-intersect s1 s2)) '(2))
+  (check-equal? (set->list (set-intersect s1 s3)) '(2 1))
+
+  ; 3 arguments
+  (check-equal? (set->list (set-intersect s1 s1 s1)) (set->list s1))
+  (check-equal? (set->list (set-intersect s1 s2 s3)) '(2))
+
+  (void))
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -255,6 +255,29 @@
 
   (void))
 
+;; Test `set-subtract`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 2 3))
+  (define s3 (make-set 1 2 3))
+
+  (check-equal? (set->list (set-subtract s0)) (set->list s0))
+  (check-equal? (set->list (set-subtract s1)) (set->list s1)) 
+  (check-equal? (set->list (set-subtract s2)) (set->list s2)) 
+  (check-equal? (set->list (set-subtract s3)) (set->list s3))
+
+  (check-equal? (set->list (set-subtract s3 s0)) '(2 1 3))
+  (check-equal? (set->list (set-subtract s3 s1)) '(3))
+  (check-equal? (set->list (set-subtract s3 s2)) '(1))
+  (check-equal? (set->list (set-subtract s3 s3)) '())
+
+  (check-equal? (set->list (set-subtract s3 s0 s0)) '(2 1 3))
+  (check-equal? (set->list (set-subtract s3 s1 s0)) '(3))
+  (check-equal? (set->list (set-subtract s3 s1 s2)) '())
+
+  (void))
+
 ;; Test `set-map` and `set-for-each`
 (let ()
   (define s0 (make-set))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -32,23 +32,39 @@
     (set! num-failed (+ num-failed 1))))
 
 
-;; Test `make-set`, `set?`, and `set-count`
+;; Test `make-set`, `set?`, `set-count`, and `set-empty?`
 (let ()
   (define s0 (make-set))
   (check-true (set? s0))
   (check-equal? (set-count s0) 0)
+  (check-true (set-empty? s0))
 
   (define s1 (make-set 1))
   (check-true (set? s1))
   (check-equal? (set-count s1) 1)
+  (check-false (set-empty? s1))
 
   (define s2 (make-set 1 2))
   (check-true (set? s2))
   (check-equal? (set-count s2) 2)
+  (check-false (set-empty? s2))
 
   (define s3 (make-set 1 2 3))
   (check-true (set? s3))
   (check-equal? (set-count s3) 3)
+  (check-false (set-empty? s3))
+
+  (void))
+
+;; Test `set-copy`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+
+  (check-equal? (set->list (set-copy s0)) (set->list s0))
+  (check-equal? (set->list (set-copy s1)) (set->list s1))
+  (check-equal? (set->list (set-copy s2)) (set->list s2))
 
   (void))
 
@@ -94,7 +110,7 @@
   (check-false (set-member? s3 5))
   (void))
 
-;; Test `set-add!`
+;; Test `set-add!` and `set-remove!`
 (let ()
   (define s (make-set 1 2 3))
 
@@ -105,6 +121,22 @@
   (set-remove! s 4)
   (check-equal? (set-count s) 3)
   (check-false (set-member? s 4))
+
+  (void))
+
+;; Test `set-clear!`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+
+  (set-clear! s0)
+  (set-clear! s1)
+  (set-clear! s2)
+
+  (check-true (set-empty? s0))
+  (check-true (set-empty? s1))
+  (check-true (set-empty? s2))
 
   (void))
 

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -62,9 +62,9 @@
   (define s1 (make-set 1 2))
   (define s2 (make-set 1 2 3))
 
-  (check-equal? (set->list (set-copy s0)) (set->list s0))
-  (check-equal? (set->list (set-copy s1)) (set->list s1))
-  (check-equal? (set->list (set-copy s2)) (set->list s2))
+  (check-equal? (set-copy s0) s0)
+  (check-equal? (set-copy s1) s1)
+  (check-equal? (set-copy s2) s2)
 
   (void))
 
@@ -144,22 +144,6 @@
 
   (void))
 
-;; Test `set-count`
-(let ()
-  (define s0 (make-set))
-  (check-equal? (set->list s0) '())
-
-  (define s1 (make-set 1))
-  (check-equal? (set->list s1) '(1))
-
-  (define s2 (make-set 1 2))
-  (check-equal? (set->list s2) '(2 1))
-
-  (define s3 (make-set 1 2 3))
-  (check-equal? (set->list s3) '(2 1 3))
-
-  (void))
-
 ;; Test `set-member?`
 (let ()
   (define s3 (make-set 1 2 3))
@@ -208,22 +192,22 @@
   (define s3 (make-set 4 5 6))
 
   ; 0 arguments
-  (check-equal? (set->list (set-union)) '())
+  (check-equal? (set-union) (make-set))
 
   ; 1 arguments
-  (check-equal? (set->list (set-union s1)) (set->list s1))
-  (check-equal? (set->list (set-union s2)) (set->list s2))
-  (check-equal? (set->list (set-union s3)) (set->list s3))
+  (check-equal? (set-union s1) s1)
+  (check-equal? (set-union s2) s2)
+  (check-equal? (set-union s3) s3)
 
   ; 2 arguments
-  (check-equal? (set->list (set-union s0 s1)) (set->list s1))
-  (check-equal? (set->list (set-union s0 s3)) (set->list s3))
-  (check-equal? (set->list (set-union s1 s2)) '(2 1 3))
-  (check-equal? (set->list (set-union s1 s3)) '(2 6 1 5 4))
+  (check-equal? (set-union s0 s1) s1)
+  (check-equal? (set-union s0 s3) s3)
+  (check-equal? (set-union s1 s2) (make-set 1 2 3))
+  (check-equal? (set-union s1 s3) (make-set 1 2 4 5 6))
 
   ; 3 arguments
-  (check-equal? (set->list (set-union s1 s1 s1)) (set->list s1))
-  (check-equal? (set->list (set-union s1 s2 s3)) '(2 6 1 5 4 3))
+  (check-equal? (set-union s1 s1 s1) s1)
+  (check-equal? (set-union s1 s2 s3) (make-set 1 2 3 4 5 6))
 
   (void))
 
@@ -235,23 +219,23 @@
   (define s3 (make-set 1 2 3))
 
   ; 0 arguments
-  (check-equal? (set->list (set-intersect)) '())
+  (check-equal? (set-intersect) (make-set))
 
   ; 1 arguments
-  (check-equal? (set->list (set-intersect s1)) (set->list s1))
-  (check-equal? (set->list (set-intersect s2)) (set->list s2))
-  (check-equal? (set->list (set-intersect s3)) (set->list s3))
+  (check-equal? (set-intersect s1) s1)
+  (check-equal? (set-intersect s2) s2)
+  (check-equal? (set-intersect s3) s3)
 
   ; 2 arguments
-  (check-equal? (set->list (set-intersect s3 s3)) (set->list s3))
-  (check-equal? (set->list (set-intersect s0 s1)) '())
-  (check-equal? (set->list (set-intersect s0 s3)) '())
-  (check-equal? (set->list (set-intersect s1 s2)) '(2))
-  (check-equal? (set->list (set-intersect s1 s3)) '(2 1))
+  (check-equal? (set-intersect s3 s3) s3)
+  (check-equal? (set-intersect s0 s1) (make-set))
+  (check-equal? (set-intersect s0 s3) (make-set))
+  (check-equal? (set-intersect s1 s2) (make-set 2))
+  (check-equal? (set-intersect s1 s3) (make-set 1 2))
 
   ; 3 arguments
-  (check-equal? (set->list (set-intersect s1 s1 s1)) (set->list s1))
-  (check-equal? (set->list (set-intersect s1 s2 s3)) '(2))
+  (check-equal? (set-intersect s1 s1 s1) s1)
+  (check-equal? (set-intersect s1 s2 s3) (make-set 2))
 
   (void))
 
@@ -262,19 +246,19 @@
   (define s2 (make-set 2 3))
   (define s3 (make-set 1 2 3))
 
-  (check-equal? (set->list (set-subtract s0)) (set->list s0))
-  (check-equal? (set->list (set-subtract s1)) (set->list s1)) 
-  (check-equal? (set->list (set-subtract s2)) (set->list s2)) 
-  (check-equal? (set->list (set-subtract s3)) (set->list s3))
+  (check-equal? (set-subtract s0) s0)
+  (check-equal? (set-subtract s1) s1)
+  (check-equal? (set-subtract s2) s2)
+  (check-equal? (set-subtract s3) s3)
 
-  (check-equal? (set->list (set-subtract s3 s0)) '(2 1 3))
-  (check-equal? (set->list (set-subtract s3 s1)) '(3))
-  (check-equal? (set->list (set-subtract s3 s2)) '(1))
-  (check-equal? (set->list (set-subtract s3 s3)) '())
+  (check-equal? (set-subtract s3 s0) (make-set 1 2 3))
+  (check-equal? (set-subtract s3 s1) (make-set 3))
+  (check-equal? (set-subtract s3 s2) (make-set 1))
+  (check-equal? (set-subtract s3 s3) (make-set))
 
-  (check-equal? (set->list (set-subtract s3 s0 s0)) '(2 1 3))
-  (check-equal? (set->list (set-subtract s3 s1 s0)) '(3))
-  (check-equal? (set->list (set-subtract s3 s1 s2)) '())
+  (check-equal? (set-subtract s3 s0 s0) (make-set 1 2 3))
+  (check-equal? (set-subtract s3 s1 s0) (make-set 3))
+  (check-equal? (set-subtract s3 s1 s2) (make-set))
 
   (void))
 
@@ -285,20 +269,20 @@
   (define s2 (make-set 2 3))
   (define s3 (make-set 1 2 3))
 
-  (check-equal? (set->list (set-symmetric-difference s0)) (set->list s0))
-  (check-equal? (set->list (set-symmetric-difference s1)) (set->list s1)) 
-  (check-equal? (set->list (set-symmetric-difference s2)) (set->list s2)) 
-  (check-equal? (set->list (set-symmetric-difference s3)) (set->list s3))
+  (check-equal? (set-symmetric-difference s0) s0)
+  (check-equal? (set-symmetric-difference s1) s1)
+  (check-equal? (set-symmetric-difference s2) s2)
+  (check-equal? (set-symmetric-difference s3) s3)
 
-  (check-equal? (set->list (set-symmetric-difference s3 s0)) '(2 1 3))
-  (check-equal? (set->list (set-symmetric-difference s3 s1)) '(3))
-  (check-equal? (set->list (set-symmetric-difference s3 s2)) '(1))
-  (check-equal? (set->list (set-symmetric-difference s3 s3)) '())
+  (check-equal? (set-symmetric-difference s3 s0) (make-set 1 2 3))
+  (check-equal? (set-symmetric-difference s3 s1) (make-set 3))
+  (check-equal? (set-symmetric-difference s3 s2) (make-set 1))
+  (check-equal? (set-symmetric-difference s3 s3) (make-set))
 
-  (check-equal? (set->list (set-symmetric-difference s3 s0 s0)) '(2 1 3))
-  (check-equal? (set->list (set-symmetric-difference s3 s1 s0)) '(3))
-  (check-equal? (set->list (set-symmetric-difference s3 s1 s2)) '(2))
-  (check-equal? (set->list (set-symmetric-difference s3 s1 s1)) '(2 1 3))
+  (check-equal? (set-symmetric-difference s3 s0 s0) (make-set 1 2 3))
+  (check-equal? (set-symmetric-difference s3 s1 s0) (make-set 3))
+  (check-equal? (set-symmetric-difference s3 s1 s2) (make-set 2))
+  (check-equal? (set-symmetric-difference s3 s1 s1) (make-set 1 2 3))
 
   (void))
 

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -68,6 +68,66 @@
 
   (void))
 
+;; Test `subset?`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+
+  (check-true (subset? s0 s0))
+  (check-true (subset? s1 s1))
+  (check-true (subset? s2 s2))
+
+  (check-true (subset? s0 s1))
+  (check-true (subset? s0 s2))
+  (check-true (subset? s1 s2))
+
+  (check-false (subset? s1 s0))
+  (check-false (subset? s2 s0))
+  (check-false (subset? s2 s1))
+
+  (void))
+
+;; Test `proper-subset?`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+
+  (check-false (proper-subset? s0 s0))
+  (check-false (proper-subset? s1 s1))
+  (check-false (proper-subset? s2 s2))
+
+  (check-true (proper-subset? s0 s1))
+  (check-true (proper-subset? s0 s2))
+  (check-true (proper-subset? s1 s2))
+
+  (check-false (proper-subset? s1 s0))
+  (check-false (proper-subset? s2 s0))
+  (check-false (proper-subset? s2 s1))
+
+  (void))
+
+;; Test `set=?`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 1 2 3))
+
+  (check-true (set=? s0 s0))
+  (check-true (set=? s1 s1))
+  (check-true (set=? s2 s2))
+
+  (check-false (set=? s0 s1))
+  (check-false (set=? s0 s2))
+  (check-false (set=? s1 s2))
+
+  (check-false (set=? s1 s0))
+  (check-false (set=? s2 s0))
+  (check-false (set=? s2 s1))
+
+  (void))
+
 ;; Test `set->list`
 (let ()
   (define s0 (make-set))
@@ -100,7 +160,7 @@
 
   (void))
 
-;; Test `set-count`
+;; Test `set-member?`
 (let ()
   (define s3 (make-set 1 2 3))
   (check-true (set-member? s3 1))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -1,0 +1,114 @@
+;;;
+;;; Tests for 'set'
+;;;
+
+(import "../../src/library/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-true d)
+  (unless d
+    (display "[FAIL] expected #t")
+    (display ", received ")
+    (write d)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-false d)
+  (when d
+    (display "[FAIL] expected #f")
+    (display ", received ")
+    (write d)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+
+;; Test `make-set`, `set?`, and `set-count`
+(let ()
+  (define s0 (make-set))
+  (check-true (set? s0))
+  (check-equal? (set-count s0) 0)
+
+  (define s1 (make-set 1))
+  (check-true (set? s1))
+  (check-equal? (set-count s1) 1)
+
+  (define s2 (make-set 1 2))
+  (check-true (set? s2))
+  (check-equal? (set-count s2) 2)
+
+  (define s3 (make-set 1 2 3))
+  (check-true (set? s3))
+  (check-equal? (set-count s3) 3)
+
+  (void))
+
+;; Test `set->list`
+(let ()
+  (define s0 (make-set))
+  (check-equal? (set->list s0) '())
+
+  (define s1 (make-set 1))
+  (check-equal? (set->list s1) '(1))
+
+  (define s2 (make-set 1 2))
+  (check-equal? (set->list s2) '(2 1))
+
+  (define s3 (make-set 1 2 3))
+  (check-equal? (set->list s3) '(2 1 3))
+
+  (void))
+
+;; Test `set-count`
+(let ()
+  (define s0 (make-set))
+  (check-equal? (set->list s0) '())
+
+  (define s1 (make-set 1))
+  (check-equal? (set->list s1) '(1))
+
+  (define s2 (make-set 1 2))
+  (check-equal? (set->list s2) '(2 1))
+
+  (define s3 (make-set 1 2 3))
+  (check-equal? (set->list s3) '(2 1 3))
+
+  (void))
+
+;; Test `set-count`
+(let ()
+  (define s3 (make-set 1 2 3))
+  (check-true (set-member? s3 1))
+  (check-true (set-member? s3 2))
+  (check-true (set-member? s3 3))
+  (check-false (set-member? s3 4))
+  (check-false (set-member? s3 5))
+  (void))
+
+;; Test `set-add!`
+(let ()
+  (define s (make-set 1 2 3))
+
+  (set-add! s 4)
+  (check-equal? (set-count s) 4)
+  (check-true (set-member? s 4))
+
+  (set-remove! s 4)
+  (check-equal? (set-count s) 3)
+  (check-false (set-member? s 4))
+
+  (void))
+
+
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/test/base/set.min
+++ b/test/base/set.min
@@ -278,6 +278,30 @@
 
   (void))
 
+;; Test `set-symmetric-difference`
+(let ()
+  (define s0 (make-set))
+  (define s1 (make-set 1 2))
+  (define s2 (make-set 2 3))
+  (define s3 (make-set 1 2 3))
+
+  (check-equal? (set->list (set-symmetric-difference s0)) (set->list s0))
+  (check-equal? (set->list (set-symmetric-difference s1)) (set->list s1)) 
+  (check-equal? (set->list (set-symmetric-difference s2)) (set->list s2)) 
+  (check-equal? (set->list (set-symmetric-difference s3)) (set->list s3))
+
+  (check-equal? (set->list (set-symmetric-difference s3 s0)) '(2 1 3))
+  (check-equal? (set->list (set-symmetric-difference s3 s1)) '(3))
+  (check-equal? (set->list (set-symmetric-difference s3 s2)) '(1))
+  (check-equal? (set->list (set-symmetric-difference s3 s3)) '())
+
+  (check-equal? (set->list (set-symmetric-difference s3 s0 s0)) '(2 1 3))
+  (check-equal? (set->list (set-symmetric-difference s3 s1 s0)) '(3))
+  (check-equal? (set->list (set-symmetric-difference s3 s1 s2)) '(2))
+  (check-equal? (set->list (set-symmetric-difference s3 s1 s1)) '(2 1 3))
+
+  (void))
+
 ;; Test `set-map` and `set-for-each`
 (let ()
   (define s0 (make-set))


### PR DESCRIPTION
This PR adds a set datatype with the following procedures:
```
make-set
set?
set-member?
set-copy
set-empty?
set-count
set->list
subset?
proper-subset?
set=?
set-add!
set-remove!
set-clear!
set-map
set-for-each
set-union
set-intersect
set-subtract
set-symmetric-difference
```

Fixes for `equal?` and `equal-hash` also included.