### PR TITLE
Enumerations

### DIFF
--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -166,7 +166,8 @@ void populate_env(minim_object *env) {
     add_procedure("$record-rtd", record_rtd_proc, 1, 1);
     add_procedure("$record-ref", record_ref_proc, 2, 2);
     add_procedure("$record-set!", record_set_proc, 3, 3);
-    add_procedure("current-record-equal-procedure", current_record_equal_procedure_proc, 0, 1);
+    add_procedure("$current-record-equal-procedure", current_record_equal_procedure_proc, 0, 1);
+    add_procedure("$current-record-hash-procedure", current_record_hash_procedure_proc, 0, 1);
 
     add_procedure("box?", is_box_proc, 1, 1);
     add_procedure("box", box_proc, 1, 1);
@@ -319,6 +320,7 @@ void minim_boot_init() {
     command_line(th) = minim_null;
     boot_expander(th) = minim_true;
     record_equal_proc(th) = minim_false;
+    record_hash_proc(th) = minim_false;
 
     values_buffer(th) = GC_alloc(INIT_VALUES_BUFFER_LEN * sizeof(minim_object*));
     values_buffer_size(th) = INIT_VALUES_BUFFER_LEN;

--- a/src/boot/c/boot.c
+++ b/src/boot/c/boot.c
@@ -166,6 +166,7 @@ void populate_env(minim_object *env) {
     add_procedure("$record-rtd", record_rtd_proc, 1, 1);
     add_procedure("$record-ref", record_ref_proc, 2, 2);
     add_procedure("$record-set!", record_set_proc, 3, 3);
+    add_procedure("current-record-equal-procedure", current_record_equal_procedure_proc, 0, 1);
 
     add_procedure("box?", is_box_proc, 1, 1);
     add_procedure("box", box_proc, 1, 1);
@@ -317,6 +318,8 @@ void minim_boot_init() {
     current_directory(th) = make_string2(get_current_dir());
     command_line(th) = minim_null;
     boot_expander(th) = minim_true;
+    record_equal_proc(th) = minim_false;
+
     values_buffer(th) = GC_alloc(INIT_VALUES_BUFFER_LEN * sizeof(minim_object*));
     values_buffer_size(th) = INIT_VALUES_BUFFER_LEN;
     values_buffer_count(th) = 0;

--- a/src/boot/s/expand.min
+++ b/src/boot/s/expand.min
@@ -216,7 +216,7 @@
           (cond
             [(null? (cdr exprs))
              (cond
-               [(define-values-form? expr*)
+               [(or (define-values-form? expr*) (define-syntaxes-form? expr*))
                 (error 'begin "last form is not an expression" (car exprs))]
                [(null? defines)
                 (list expr*)]
@@ -229,6 +229,24 @@
                       expr*)))])]
             [(begin-form? expr*)
              (loop (append (cdr (syntax->list expr*)) (cdr exprs)) defines)]
+            [(define-syntaxes-form? expr*)
+             ; this creates a break in the body:
+             ; create a `letrec-values` for pending bindings
+             ; create `let-syntaxes` for the current macro
+             ; call `expand/body` on remaining expressions
+             (define form (syntax->list expr*))
+             (define ids (cadr form))
+             (define value (caddr form))
+             (list
+               (expand/expr 
+                 (datum->syntax
+                   (list
+                     (quote-syntax letrec-values)
+                     (reverse defines)
+                     (cons (quote-syntax let-syntaxes)
+                       (cons (list (list ids value))
+                         (cdr exprs)))))
+                 xforms))]
             [(define-values-form? expr*)
              (define form (syntax->list expr*))
              (define ids (cadr form))

--- a/src/core/c/hashtable.c
+++ b/src/core/c/hashtable.c
@@ -163,7 +163,8 @@ static size_t equal_hash2(minim_object *o, size_t hash) {
     case MINIM_BOX_TYPE:
         return equal_hash2(minim_box_contents(o), hash);
     case MINIM_RECORD_TYPE:
-        // See note in `minim_is_equal` about record equality
+        // Hashing records using `equal?` recursively
+        // descends through the record
         if (is_record_rtd(o)) {
             return eq_hash2(o, hash);
         } else {

--- a/src/core/c/object.c
+++ b/src/core/c/object.c
@@ -99,25 +99,17 @@ int minim_is_equal(minim_object *a, minim_object *b) {
         //  (i)  they share record types
         //  (ii) each of their fields are `equal?`
         //
-        if (is_record_rtd(a)) {
-            if (!is_record_rtd(b))
-                return 0;
-
-            // this should use eq? based comparisons
-            return minim_is_eq(a, b);
+        if (record_equal_proc(current_thread()) != minim_false &&
+            is_record_value(a) &&
+            is_record_value(b)) {
+            // Unsafe code to follow
+            clear_call_args();
+            push_call_arg(a);
+            push_call_arg(b);
+            push_call_arg(env_lookup_var(global_env(current_thread()), intern("equal?")));
+            return (call_with_args(record_equal_proc(current_thread()), global_env(current_thread())) == minim_false ? 0 : 1);
         } else {
-            if (!is_record_value(b))
-                return 0;
-
-            if (minim_record_rtd(a) != minim_record_rtd(b))
-                return 0;
-            
-            for (i = 0; i < minim_record_count(a); ++i) {
-                if (!minim_is_equal(minim_record_ref(a, i), minim_record_ref(b, i)))
-                    return 0;
-            }
-
-            return 1;
+            return minim_is_eq(a, b);
         }
 
     default:

--- a/src/core/c/object.c
+++ b/src/core/c/object.c
@@ -94,16 +94,12 @@ int minim_is_equal(minim_object *a, minim_object *b) {
         // an error.
         //
         // Minim implements record equality in the following way:
-        // Any record type descriptor is only `equal?` to itself
-        // Two record values are equal if and only if
-        //  (i)  they share record types
-        //  (ii) each of their fields are `equal?`
-        //
+        // By default, records of the same type are not `equal?`, but this behavior
+        // can be overriden by modifying `current-record-equal-procedure`.
         if (record_equal_proc(current_thread()) != minim_false &&
             is_record_value(a) &&
             is_record_value(b)) {
             // Unsafe code to follow
-            clear_call_args();
             push_call_arg(a);
             push_call_arg(b);
             push_call_arg(env_lookup_var(global_env(current_thread()), intern("equal?")));

--- a/src/core/c/record.c
+++ b/src/core/c/record.c
@@ -327,3 +327,16 @@ minim_object *current_record_equal_procedure_proc(int argc, minim_object **args)
         return minim_void;
     }
 }
+
+minim_object *current_record_hash_procedure_proc(int argc, minim_object **args) {
+    // (-> proc)
+    // (-> proc void)
+    if (argc == 0) {
+        return record_hash_proc(current_thread());
+    } else {
+        if (!minim_is_proc(args[0]))
+            bad_type_exn("current-record-hash-procedure", "procedue?", args[0]);
+        record_hash_proc(current_thread()) = args[0];
+        return minim_void;
+    }
+}

--- a/src/core/c/record.c
+++ b/src/core/c/record.c
@@ -269,15 +269,6 @@ minim_object *record_rtd_proc(int argc, minim_object **args) {
     // (-> record rtd)
     if (!is_record_value(args[0]))
         bad_type_exn("record-rtd", "record?", args[0]);
-    
-    // if (record_is_opaque(args[0])) {
-    //     fprintf(stderr, "record-rtd: cannot inspect opaque records\n");
-    //     fprintf(stderr, " record: ");
-    //     write_object(stderr, args[0]);
-    //     fprintf(stderr, "\n");
-    //     exit(1);
-    // }
-
     return minim_record_rtd(args[0]);
 }
 
@@ -322,4 +313,17 @@ minim_object *record_set_proc(int argc, minim_object **args) {
 
     minim_record_ref(args[0], idx) = args[2];
     return minim_void;
+}
+
+minim_object *current_record_equal_procedure_proc(int argc, minim_object **args) {
+    // (-> proc)
+    // (-> proc void)
+    if (argc == 0) {
+        return record_equal_proc(current_thread());
+    } else {
+        if (!minim_is_proc(args[0]))
+            bad_type_exn("current-record-equal-procedure", "procedue?", args[0]);
+        record_equal_proc(current_thread()) = args[0];
+        return minim_void;
+    }
 }

--- a/src/core/c/syntax.c
+++ b/src/core/c/syntax.c
@@ -62,7 +62,7 @@ minim_object *to_syntax(minim_object *o) {
         return make_syntax(it, minim_false);
 
     default:
-        fprintf(stderr, "datum->syntax: cannot convert to syntax");
+        fprintf(stderr, "datum->syntax: cannot convert to syntax\n");
         minim_shutdown(1);
     }
 }

--- a/src/core/minim.h
+++ b/src/core/minim.h
@@ -547,6 +547,7 @@ typedef struct minim_thread {
     minim_object *current_directory;
     minim_object *boot_expander;
     minim_object *command_line;
+    minim_object *record_equal_proc;
 
     minim_object **values_buffer;
     int values_buffer_size;
@@ -561,6 +562,7 @@ typedef struct minim_thread {
 #define current_directory(th)           ((th)->current_directory)
 #define boot_expander(th)               ((th)->boot_expander)
 #define command_line(th)                ((th)->command_line)
+#define record_equal_proc(th)           ((th)->record_equal_proc)
 
 #define values_buffer(th)               ((th)->values_buffer)
 #define values_buffer_ref(th, idx)      ((th)->values_buffer[(idx)])
@@ -737,6 +739,7 @@ DEFINE_PRIM_PROC(record_type_field_mutable);
 DEFINE_PRIM_PROC(make_record);
 DEFINE_PRIM_PROC(record_ref);
 DEFINE_PRIM_PROC(record_set);
+DEFINE_PRIM_PROC(current_record_equal_procedure);
 // boxes
 DEFINE_PRIM_PROC(is_box);
 DEFINE_PRIM_PROC(box);

--- a/src/core/minim.h
+++ b/src/core/minim.h
@@ -548,6 +548,7 @@ typedef struct minim_thread {
     minim_object *boot_expander;
     minim_object *command_line;
     minim_object *record_equal_proc;
+    minim_object *record_hash_proc;
 
     minim_object **values_buffer;
     int values_buffer_size;
@@ -563,6 +564,7 @@ typedef struct minim_thread {
 #define boot_expander(th)               ((th)->boot_expander)
 #define command_line(th)                ((th)->command_line)
 #define record_equal_proc(th)           ((th)->record_equal_proc)
+#define record_hash_proc(th)            ((th)->record_hash_proc)
 
 #define values_buffer(th)               ((th)->values_buffer)
 #define values_buffer_ref(th, idx)      ((th)->values_buffer[(idx)])
@@ -740,6 +742,7 @@ DEFINE_PRIM_PROC(make_record);
 DEFINE_PRIM_PROC(record_ref);
 DEFINE_PRIM_PROC(record_set);
 DEFINE_PRIM_PROC(current_record_equal_procedure);
+DEFINE_PRIM_PROC(current_record_hash_procedure);
 // boxes
 DEFINE_PRIM_PROC(is_box);
 DEFINE_PRIM_PROC(box);

--- a/src/library/base.min
+++ b/src/library/base.min
@@ -2,14 +2,16 @@
 ;;; Top-level import for base library
 ;;;
 
-(import "private/list.min"
+(import "private/enum.min"
+        "private/list.min"
         "private/path.min"
         "private/pre-base.min"
         "private/record.min"
         "private/set.min"
         "private/string.min")
 
-(export (all "private/list.min")
+(export (all "private/enum.min")
+        (all "private/list.min")
         (all "private/path.min")
         (all "private/pre-base.min")
         (all "private/record.min")

--- a/src/library/expander.min
+++ b/src/library/expander.min
@@ -223,7 +223,7 @@
           (cond
             [(null? (cdr exprs))
              (cond
-               [(define-values-form? expr*)
+               [(or (define-values-form? expr*) (define-syntaxes-form? expr*))
                 (error 'begin "last form is not an expression" (car exprs))]
                [(null? defines)
                 (list expr*)]
@@ -236,6 +236,24 @@
                       expr*)))])]
             [(begin-form? expr*)
              (loop (append (cdr (syntax->list expr*)) (cdr exprs)) defines)]
+            [(define-syntaxes-form? expr*)
+             ; this creates a break in the body:
+             ; create a `letrec-values` for pending bindings
+             ; create `let-syntaxes` for the current macro
+             ; call `expand/body` on remaining expressions
+             (define form (syntax->list expr*))
+             (define ids (cadr form))
+             (define value (caddr form))
+             (list
+               (expand/expr 
+                 (datum->syntax
+                   (list
+                     (quote-syntax letrec-values)
+                     (reverse defines)
+                     (cons (quote-syntax let-syntaxes)
+                       (cons (list (list ids value))
+                         (cdr exprs)))))
+                 xforms))]
             [(define-values-form? expr*)
              (define form (syntax->list expr*))
              (define ids (cadr form))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -1,0 +1,32 @@
+;;;
+;;; Enumeration
+;;;
+
+(import "pre-base.min" "list.min" "record.min" "set.min")
+(export make-enumeration
+        enum-set-type?)
+
+;;
+;;  Type definition
+;;
+
+(define-record-type enum-set-type
+  (opaque #t)
+  (sealed #t)
+  (fields id universe))
+
+(define (make-enumeration xs)
+  (for-each (lambda (x)
+              (unless (symbol? x)
+                (error 'make-enumeration "expected a symbol?" x)))
+            xs)
+  (define-record-type empty)
+  (make-enum-set-type empty xs))
+
+;;
+;;  Low-level procedures
+;;
+
+(define (enum-set-universe enum-type)
+  (define-record-type empty)
+  (enum-set empty (enum-set-type-universe enum-type)))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -27,15 +27,13 @@
   (opaque #t)
   (sealed #t)
   (fields
-    id            ; record?
     universe      ; list?
     universe-set  ; set?
   )
   (protocol
     (lambda (p)
       (lambda (univ)
-        (define-record-type id)
-        (p id univ (apply make-set univ))))))
+        (p univ (apply make-set univ))))))
 
 ;; The `id` field is to prevent any two
 ;; enum-set-types from being comparable
@@ -43,7 +41,6 @@
   (opaque #t)
   (sealed #t)
   (fields
-    id          ; record?
     enum-type   ; record?
     vals        ; list?
     val-set     ; set?
@@ -51,8 +48,7 @@
   (protocol
     (lambda (p)
       (lambda (enum-type vals)
-        (define-record-type set-id)
-        (p set-id enum-type vals (apply make-set vals))))))
+        (p enum-type vals (apply make-set vals))))))
 
 (define (make-enumeration xs)
   (for-each (lambda (x)

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -4,7 +4,10 @@
 
 (import "pre-base.min" "list.min" "record.min" "set.min")
 (export make-enumeration
-        enum-set-type?)
+        enum-set-type?
+        enum-set->list
+        enum-set-universe
+        enum-set-constructor)
 
 ;;
 ;;  Type definition
@@ -13,7 +16,7 @@
 (define-record-type enum-set-type
   (opaque #t)
   (sealed #t)
-  (fields id universe))
+  (fields id universe subset))
 
 (define (make-enumeration xs)
   (for-each (lambda (x)
@@ -21,12 +24,28 @@
                 (error 'make-enumeration "expected a symbol?" x)))
             xs)
   (define-record-type empty)
-  (make-enum-set-type empty xs))
+  (make-enum-set-type empty xs xs))
 
 ;;
-;;  Low-level procedures
+;;  Procedures
 ;;
+
+(define enum-set->list enum-set-type-subset)
 
 (define (enum-set-universe enum-type)
+  (define universe (enum-set-type-universe enum-type))
   (define-record-type empty)
-  (enum-set empty (enum-set-type-universe enum-type)))
+  (make-enum-set-type empty universe universe))
+
+(define (enum-set-constructor enum-type)
+  (define universe (enum-set-type-universe enum-type))
+  (lambda (xs)
+    (define-record-type empty)
+    (make-enum-set-type
+      empty
+      universe
+      (let loop ([ys universe] [in-xs '()])
+        (cond
+          [(null? ys) (reverse in-xs)]
+          [(member (car ys) xs) (loop (cdr ys) (cons (car ys) in-xs))]
+          [else (loop (cdr ys) in-xs)])))))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -8,8 +8,10 @@
         enum-set->list
         enum-set-universe
         enum-set-constructor
+        enum-set-indexer
         enum-set-member?
-        enum-set-subset?)
+        enum-set-subset?
+        enum-set=?)
 
 ;;
 ;;  Type definition
@@ -73,6 +75,15 @@
           [(set-member? xs* (car ys)) (loop (cdr ys) (cons (car ys) in-xs))]
           [else (loop (cdr ys) in-xs)])))))
 
+(define (enum-set-indexer enum-type)
+  (unless (enum-set-type? enum-type)
+    (error 'enum-set-indexer "expected an enum-set-type?" enum-type))
+  (define universe (enum-set-type-universe enum-type))
+  (lambda (x)
+    (unless (symbol? x)
+      (error 'enum-set-indexer "expected a symbol?" x))
+    (index-of x universe)))
+
 (define (enum-set-member? x enum-type)
   (unless (enum-set-type? enum-type)
     (error 'enum-set-constructor "expected an enum-set-type?" enum-type))
@@ -82,10 +93,20 @@
 (define (list-subset? l1 l2)
   (subset? (apply make-set l1) (apply make-set l2)))
 
+(define ($enum-set-subset? e1 e2)
+  (and (list-subset? (enum-set-type-universe e1) (enum-set-type-universe e2))
+       (list-subset? (enum-set-type-subset e1) (enum-set-type-subset e2))))
+
 (define (enum-set-subset? e1 e2)
   (unless (enum-set-type? e1)
     (error 'enum-subset? "expected an enum-set-type?" e1))
   (unless (enum-set-type? e2)
     (error 'enum-subset? "expected an enum-set-type?" e2))
-  (and (list-subset? (enum-set-type-universe e1) (enum-set-type-universe e2))
-       (list-subset? (enum-set-type-subset e1) (enum-set-type-subset e2))))
+  ($enum-set-subset? e1 e2))
+
+(define (enum-set=? e1 e2)
+  (unless (enum-set-type? e1)
+    (error 'enum-subset? "expected an enum-set-type?" e1))
+  (unless (enum-set-type? e2)
+    (error 'enum-set=? "expected an enum-set-type?" e2))
+  (and ($enum-set-subset? e1 e2) ($enum-set-subset? e2 e1)))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -15,7 +15,8 @@
         enum-set-union
         enum-set-intersect
         enum-set-difference
-        enum-set-complement)
+        enum-set-complement
+        enum-set-projection)
 
 ;;
 ;;  Type definition
@@ -162,10 +163,20 @@
 
 (define (enum-set-complement enum-set)
   (unless (enum-set? enum-set)
-    (error name "expected an enum-set?" enum-set))
+    (error 'enum-set-complement "expected an enum-set?" enum-set))
   (define enum-type (enum-set-enum-type enum-set))
   (define vs (enum-set-val-set enum-set))
   (make-enum-set enum-type
     (filter (lambda (x) (not (set-member? vs x)))
             (enum-set-type-universe enum-type))))
 
+(define (enum-set-projection e1 e2)
+  (unless (enum-set? e1)
+    (error 'enum-set-projection "expected an enum-set?" e1))
+  (unless (enum-set? e2)
+    (error 'enum-set-projection "expected an enum-set?" e2))
+  (define universe (enum-set-type-universe-set (enum-set-enum-type e2)))
+  (define constructor (enum-set-constructor e2))
+  (constructor
+    (filter (lambda (x) (set-member? universe x))
+            (enum-set-vals e1))))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -2,8 +2,9 @@
 ;;; Enumeration
 ;;;
 
-(import "pre-base.min" "list.min" "record.min" "set.min")
-(export make-enumeration
+(import "pre-base.min" "list.min" "record.min" "set.min" "gen-temp.min")
+(export define-enumeration
+        make-enumeration
         enum-set?
         enum-set->list
         enum-set-universe
@@ -180,3 +181,49 @@
   (constructor
     (filter (lambda (x) (set-member? universe x))
             (enum-set-vals e1))))
+
+;;
+;;  Macros
+;;
+
+(define-syntax (define-enumeration stx)
+  (syntax-case stx ()
+    [(_ name (values ...) constructor)
+     (if (identifier? #'name)
+         (let ([ids (syntax->list #'(values ...))])
+           (for-each (lambda (id)
+                       (unless (identifier? id)
+                         (error 'define-enumeration "expected an identifier" stx id)))
+                     ids)
+           (unless (identifier? #'constructor)
+             (error 'define-enumeration "expected an identifier" stx #'constructor))
+           (with-syntax ([(elts ...) (list 'elts '...)]
+                         [id (gen-temp-id (symbol->string (syntax->datum #'name)))])
+             #'(begin
+                 (define id (make-enumeration '(values ...)))
+                 (define-syntax (constructor stx)
+                   (syntax-case stx ()
+                     [(_ elts ...)
+                      #'((enum-set-constructor id) '(elts ...))]
+                     [(_ . _)
+                      (error 'constructor "bad syntax" stx)]))
+                 (define-syntax (name stx)
+                   (syntax-case stx ()
+                     [(_ elt)
+                      (if (identifier? #'elt)
+                          (if (member (syntax->datum #'elt) '(values ...))
+                              #''elt
+                              (error 'name "identifier not in universe" stx #'elt))
+                          (error 'name "expected an identifier" stx #'elt))]
+                     [(_ . _)
+                      (error 'name "bad syntax" stx)]))
+             )))
+         (error 'define-enumeration "expected an identifier" #'name))]
+    [(_ name value-spec constructor _ ...)
+     (syntax-error 'define-enumeration "bad syntax" stx)]
+    [(_ name value-spec)
+     (syntax-error 'define-enumeration "missing constructor name" stx)]
+    [(_ name)
+     (syntax-error 'define-enumeration "missing enumeration values and constructor name" stx)]
+    [(_ . _)
+     (syntax-error 'define-enumeration "bad syntax" stx)]))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -11,7 +11,10 @@
         enum-set-indexer
         enum-set-member?
         enum-set-subset?
-        enum-set=?)
+        enum-set=?
+        enum-set-union
+        enum-set-intersect
+        enum-set-difference)
 
 ;;
 ;;  Type definition
@@ -60,7 +63,8 @@
 ;;  Procedures
 ;;
 
-(define enum-set->list enum-set-vals)
+(define (enum-set->list enum-set)
+  (enum-set-vals enum-set))
 
 (define (enum-set-universe enum-set)
   (unless (enum-set? enum-set)
@@ -127,3 +131,30 @@
   (unless (enum-set? e2)
     (error 'enum-set=? "expected an enum-set?" e2))
   (and ($enum-set-subset? e1 e2) ($enum-set-subset? e2 e1)))
+
+(define (enum-set-merger name member?)
+  (lambda (e1 e2)
+    (unless (enum-set? e1)
+      (error name "expected an enum-set?" e1))
+    (unless (enum-set? e2)
+      (error name "expected an enum-set?" e2))
+    (unless (eq? (enum-set-enum-type e1) (enum-set-enum-type e2))
+      (error name "unioning enum sets of different types" e1 e2))
+    (define enum-type (enum-set-enum-type e1))
+    (define vs1 (enum-set-val-set e1))
+    (define vs2 (enum-set-val-set e2))
+    (make-enum-set enum-type (filter (member? vs1 vs2) (enum-set-type-universe enum-type)))))
+
+(define-values (enum-set-union enum-set-intersect enum-set-difference)
+  (values (enum-set-merger 'enum-set-union
+            (lambda (s1 s2)
+              (lambda (x)
+                (or (set-member? s1 x) (set-member? s2 x)))))
+          (enum-set-merger 'enum-set-intersect
+            (lambda (s1 s2)
+              (lambda (x)
+                (and (set-member? s1 x) (set-member? s2 x)))))
+          (enum-set-merger 'enum-set-difference
+            (lambda (s1 s2)
+              (lambda (x)
+                (and (set-member? s1 x) (not (set-member? s2 x))))))))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -14,7 +14,8 @@
         enum-set=?
         enum-set-union
         enum-set-intersect
-        enum-set-difference)
+        enum-set-difference
+        enum-set-complement)
 
 ;;
 ;;  Type definition
@@ -158,3 +159,13 @@
             (lambda (s1 s2)
               (lambda (x)
                 (and (set-member? s1 x) (not (set-member? s2 x))))))))
+
+(define (enum-set-complement enum-set)
+  (unless (enum-set? enum-set)
+    (error name "expected an enum-set?" enum-set))
+  (define enum-type (enum-set-enum-type enum-set))
+  (define vs (enum-set-val-set enum-set))
+  (make-enum-set enum-type
+    (filter (lambda (x) (not (set-member? vs x)))
+            (enum-set-type-universe enum-type))))
+

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -4,7 +4,7 @@
 
 (import "pre-base.min" "list.min" "record.min" "set.min")
 (export make-enumeration
-        enum-set-type?
+        enum-set?
         enum-set->list
         enum-set-universe
         enum-set-constructor
@@ -17,49 +17,61 @@
 ;;  Type definition
 ;;
 
-;; The `id` field is to prevent any two
-;; enum-set-types from being comparable
 (define-record-type enum-set-type
   (opaque #t)
   (sealed #t)
   (fields
-    id        ; record?
-    universe  ; list?
-    subset    ; list?
+    id            ; record?
+    universe      ; list?
+    universe-set  ; set?
   )
   (protocol
     (lambda (p)
-      (lambda (univ xs)
-        (define-record-type unique)
-        (p unique univ xs)))))
+      (lambda (univ)
+        (define-record-type id)
+        (p id univ (apply make-set univ))))))
+
+;; The `id` field is to prevent any two
+;; enum-set-types from being comparable
+(define-record-type enum-set
+  (opaque #t)
+  (sealed #t)
+  (fields
+    id          ; record?
+    enum-type   ; record?
+    vals        ; list?
+    val-set     ; set?
+  )
+  (protocol
+    (lambda (p)
+      (lambda (enum-type vals)
+        (define-record-type set-id)
+        (p set-id enum-type vals (apply make-set vals))))))
 
 (define (make-enumeration xs)
   (for-each (lambda (x)
               (unless (symbol? x)
                 (error 'make-enumeration "expected a symbol?" x)))
             xs)
-  (make-enum-set-type xs xs))
-
-;; Unchecked constructor for a new enum set with values `xs`
-;; within the same universe as `enum-type`.
-(define ($make-derived-enumeration enum-type xs)
-  (make-enum-set-type (enum-set-type-universe enum-type) xs))
+  (define enum-type (make-enum-set-type xs))
+  (make-enum-set enum-type xs))
 
 ;;
 ;;  Procedures
 ;;
 
-(define enum-set->list enum-set-type-subset)
+(define enum-set->list enum-set-vals)
 
-(define (enum-set-universe enum-type)
-  (unless (enum-set-type? enum-type)
-    (error 'enum-set-universe "expected an enum-set-type?" enum-type))
-  (define universe (enum-set-type-universe enum-type))
-  (make-enum-set-type universe universe))
+(define (enum-set-universe enum-set)
+  (unless (enum-set? enum-set)
+    (error 'enum-set-universe "expected an enum-set?" enum-set))
+  (define enum-type (enum-set-enum-type enum-set))
+  (make-enum-set enum-type (enum-set-type-universe enum-type)))
 
-(define (enum-set-constructor enum-type)
-  (unless (enum-set-type? enum-type)
-    (error 'enum-set-constructor "expected an enum-set-type?" enum-type))
+(define (enum-set-constructor enum-set)
+  (unless (enum-set? enum-set)
+    (error 'enum-set-constructor "expected an enum-set?" enum-set))
+  (define enum-type (enum-set-enum-type enum-set))
   (define universe (enum-set-type-universe enum-type))
   (lambda (xs)
     (for-each (lambda (x)
@@ -67,7 +79,7 @@
                   (error 'enum-set-constructor "expected a symbol?" x)))
               xs)
     (define xs* (apply make-set xs))
-    ($make-derived-enumeration
+    (make-enum-set
       enum-type
       (let loop ([ys universe] [in-xs '()])
         (cond
@@ -75,38 +87,43 @@
           [(set-member? xs* (car ys)) (loop (cdr ys) (cons (car ys) in-xs))]
           [else (loop (cdr ys) in-xs)])))))
 
-(define (enum-set-indexer enum-type)
-  (unless (enum-set-type? enum-type)
-    (error 'enum-set-indexer "expected an enum-set-type?" enum-type))
+(define (enum-set-indexer enum-set)
+  (unless (enum-set? enum-set)
+    (error 'enum-set-indexer "expected an enum-set?" enum-set))
+  (define enum-type (enum-set-enum-type enum-set))
   (define universe (enum-set-type-universe enum-type))
   (lambda (x)
     (unless (symbol? x)
       (error 'enum-set-indexer "expected a symbol?" x))
     (index-of x universe)))
 
-(define (enum-set-member? x enum-type)
-  (unless (enum-set-type? enum-type)
-    (error 'enum-set-constructor "expected an enum-set-type?" enum-type))
-  (define s (apply make-set (enum-set-type-subset enum-type)))
-  (and (symbol? x) (set-member? s x)))
+(define ($enum-set-member? x enum-set)
+  (set-member? (enum-set-val-set enum-set) x))
+
+(define (enum-set-member? x enum-set)
+  (unless (enum-set? enum-set)
+    (error 'enum-set-member? "expected an enum-set?" enum-set))
+  ($enum-set-member? x enum-set))
 
 (define (list-subset? l1 l2)
   (subset? (apply make-set l1) (apply make-set l2)))
 
 (define ($enum-set-subset? e1 e2)
-  (and (list-subset? (enum-set-type-universe e1) (enum-set-type-universe e2))
-       (list-subset? (enum-set-type-subset e1) (enum-set-type-subset e2))))
+  (define t1 (enum-set-enum-type e1))
+  (define t2 (enum-set-enum-type e2))
+  (and (subset? (enum-set-type-universe-set t1) (enum-set-type-universe-set t2))
+       (subset? (enum-set-val-set e1) (enum-set-val-set e2))))
 
 (define (enum-set-subset? e1 e2)
-  (unless (enum-set-type? e1)
-    (error 'enum-subset? "expected an enum-set-type?" e1))
-  (unless (enum-set-type? e2)
-    (error 'enum-subset? "expected an enum-set-type?" e2))
+  (unless (enum-set? e1)
+    (error 'enum-subset? "expected an enum-set?" e1))
+  (unless (enum-set? e2)
+    (error 'enum-subset? "expected an enum-set?" e2))
   ($enum-set-subset? e1 e2))
 
 (define (enum-set=? e1 e2)
-  (unless (enum-set-type? e1)
-    (error 'enum-subset? "expected an enum-set-type?" e1))
-  (unless (enum-set-type? e2)
-    (error 'enum-set=? "expected an enum-set-type?" e2))
+  (unless (enum-set? e1)
+    (error 'enum-subset? "expected an enum-set?" e1))
+  (unless (enum-set? e2)
+    (error 'enum-set=? "expected an enum-set?" e2))
   (and ($enum-set-subset? e1 e2) ($enum-set-subset? e2 e1)))

--- a/src/library/private/enum.min
+++ b/src/library/private/enum.min
@@ -7,24 +7,41 @@
         enum-set-type?
         enum-set->list
         enum-set-universe
-        enum-set-constructor)
+        enum-set-constructor
+        enum-set-member?
+        enum-set-subset?)
 
 ;;
 ;;  Type definition
 ;;
 
+;; The `id` field is to prevent any two
+;; enum-set-types from being comparable
 (define-record-type enum-set-type
   (opaque #t)
   (sealed #t)
-  (fields id universe subset))
+  (fields
+    id        ; record?
+    universe  ; list?
+    subset    ; list?
+  )
+  (protocol
+    (lambda (p)
+      (lambda (univ xs)
+        (define-record-type unique)
+        (p unique univ xs)))))
 
 (define (make-enumeration xs)
   (for-each (lambda (x)
               (unless (symbol? x)
                 (error 'make-enumeration "expected a symbol?" x)))
             xs)
-  (define-record-type empty)
-  (make-enum-set-type empty xs xs))
+  (make-enum-set-type xs xs))
+
+;; Unchecked constructor for a new enum set with values `xs`
+;; within the same universe as `enum-type`.
+(define ($make-derived-enumeration enum-type xs)
+  (make-enum-set-type (enum-set-type-universe enum-type) xs))
 
 ;;
 ;;  Procedures
@@ -33,19 +50,42 @@
 (define enum-set->list enum-set-type-subset)
 
 (define (enum-set-universe enum-type)
+  (unless (enum-set-type? enum-type)
+    (error 'enum-set-universe "expected an enum-set-type?" enum-type))
   (define universe (enum-set-type-universe enum-type))
-  (define-record-type empty)
-  (make-enum-set-type empty universe universe))
+  (make-enum-set-type universe universe))
 
 (define (enum-set-constructor enum-type)
+  (unless (enum-set-type? enum-type)
+    (error 'enum-set-constructor "expected an enum-set-type?" enum-type))
   (define universe (enum-set-type-universe enum-type))
   (lambda (xs)
-    (define-record-type empty)
-    (make-enum-set-type
-      empty
-      universe
+    (for-each (lambda (x)
+                (unless (symbol? x)
+                  (error 'enum-set-constructor "expected a symbol?" x)))
+              xs)
+    (define xs* (apply make-set xs))
+    ($make-derived-enumeration
+      enum-type
       (let loop ([ys universe] [in-xs '()])
         (cond
           [(null? ys) (reverse in-xs)]
-          [(member (car ys) xs) (loop (cdr ys) (cons (car ys) in-xs))]
+          [(set-member? xs* (car ys)) (loop (cdr ys) (cons (car ys) in-xs))]
           [else (loop (cdr ys) in-xs)])))))
+
+(define (enum-set-member? x enum-type)
+  (unless (enum-set-type? enum-type)
+    (error 'enum-set-constructor "expected an enum-set-type?" enum-type))
+  (define s (apply make-set (enum-set-type-subset enum-type)))
+  (and (symbol? x) (set-member? s x)))
+
+(define (list-subset? l1 l2)
+  (subset? (apply make-set l1) (apply make-set l2)))
+
+(define (enum-set-subset? e1 e2)
+  (unless (enum-set-type? e1)
+    (error 'enum-subset? "expected an enum-set-type?" e1))
+  (unless (enum-set-type? e2)
+    (error 'enum-subset? "expected an enum-set-type?" e2))
+  (and (list-subset? (enum-set-type-universe e1) (enum-set-type-universe e2))
+       (list-subset? (enum-set-type-subset e1) (enum-set-type-subset e2))))

--- a/src/library/private/list.min
+++ b/src/library/private/list.min
@@ -55,7 +55,7 @@
           [(pair? xs) (if (f (car xs))
                           (loop (cdr xs) (cons (car xs) acc))
                           (loop (cdr xs) acc))]
-          [else       (error 'map "expected a list" lst)])))
+          [else       (error 'filter "expected a list" lst)])))
 
 (define (foldl f acc lst)
   (let loop ([xs lst] [acc acc])

--- a/src/library/private/list.min
+++ b/src/library/private/list.min
@@ -8,7 +8,8 @@
         filter
         foldl foldr
         assoc
-        enumerate)
+        enumerate
+        index-of)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; accessors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -81,3 +82,10 @@
   (let loop ([lst lst] [i 0] [acc '()])
     (cond [(null? lst) (reverse acc)]
           [else (loop (cdr lst) (+ i 1) (cons (f (car lst) i) acc))])))
+
+(define (index-of k lst)
+  (let loop ([lst lst] [i 0])
+    (cond
+      [(null? lst) #f]
+      [(equal? k (car lst)) i]
+      [else (loop (cdr lst) (+ i 1))])))

--- a/src/library/private/record.min
+++ b/src/library/private/record.min
@@ -9,6 +9,7 @@
         record-predicate
         record-accessor
         record-mutator
+        record-type-equal-procedure
         define-record-type)
 
 (define (record-type-size rtd)
@@ -92,6 +93,43 @@
     ($record-set! r idx* v)))
 
 ;;
+;;  Record equivalence
+;;
+
+(define $record-eq-procs (make-hashtable))
+
+(define (record-type-equal-procedure rtd equal-proc)
+  (unless (record-type-descriptor? rtd)
+    (error 'record-type-equal-procedure "expected a record type descriptor" rtd))
+  (hashtable-set! $record-eq-procs rtd equal-proc))
+
+(define (record-equal? a b rec-equal?)
+  (define a-rtd ($record-rtd a))
+  (define b-rtd ($record-rtd b))
+  (cond
+    [(eq? a-rtd b-rtd)
+     (define proc (hashtable-ref $record-eq-procs a-rtd #f))
+     (cond
+       [proc
+        (let loop ([rtd a-rtd] [i 0])
+          (let ([prtd (record-type-parent rtd)])
+            (if prtd
+                (let loop2 ([fields (record-type-fields rtd)] [j 0])
+                  (if (null? fields)
+                      (loop prtd (+ i j))
+                      (let ([acc (record-accessor rtd j)])
+                        (if (rec-equal? (acc a) (acc b))
+                            (loop2 (cdr fields) (+ i 1))
+                            #f))))
+                #t)))]
+       [else
+        #f])]
+    [else
+     #f]))
+
+(current-record-equal-procedure record-equal?)
+
+;;
 ;;  High-level macros
 ;;
 
@@ -126,12 +164,13 @@
        (define opaque?-rtd #f)
        (define protocol-rtd #f)
        (define fields-rtd '())
+       (define equal-rtd #f)
 
        (define rname (syntax->datum #'name))
        (let loop ([clauses (syntax->list #'(cls ...))])
          (unless (null? clauses)
            (define clause (car clauses))
-           (syntax-case clause (fields parent uid sealed opaque protocol)
+           (syntax-case clause (fields parent uid sealed opaque protocol equal)
              [(parent prtd)
               (begin
                 (when (member 'parent clause-types)
@@ -166,6 +205,12 @@
                   (syntax-error 'define-record-type "duplicate clause" stx clause))
                 (set! clause-types (cons 'protocol clause-types))
                 (set! protocol-rtd #'proc))]
+             [(equal proc)
+              (begin
+                (when (member 'equal clause-types)
+                  (syntax-error 'define-record-type "duplicate clause" stx clause))
+                (set! clause-types (cons 'equal clause-types))
+                (set! equal-rtd #'proc))]
              [(fields spec ...)
               (begin
                 (when (member 'fields clause-types)
@@ -227,6 +272,7 @@
                      [sealed?* sealed?-rtd]
                      [opaque?* opaque?-rtd]
                      [protocol* protocol-rtd]
+                     [equal* equal-rtd]
                      [(fields ...)
                       (map
                         (lambda (s)
@@ -268,7 +314,8 @@
                 (if p (p c) c)))
             (define predicate (record-predicate name))
             (begin accs ...)
-            (begin muts ...))))]
+            (begin muts ...)
+            (when equal* (record-type-equal-procedure name equal*)))))]
     [(_ name cls ...) 
      ; simplified form
      (if (identifier? #'name)

--- a/src/library/private/record.min
+++ b/src/library/private/record.min
@@ -255,7 +255,7 @@
         #'(begin
             (define name
               (let ([p parent*])
-                (if (and p (record-type-opaque? p))
+                (if (and p (record-type-sealed? p))
                     (error 'define-record-type
                            "parent record type is sealed"
                            (format "record type: #<record-type:~a>" 'name)

--- a/src/library/private/record.min
+++ b/src/library/private/record.min
@@ -10,6 +10,7 @@
         record-accessor
         record-mutator
         record-type-equal-procedure
+        record-type-hash-procedure
         define-record-type)
 
 (define (record-type-size rtd)
@@ -97,37 +98,32 @@
 ;;
 
 (define $record-eq-procs (make-hashtable))
+(define $record-hash-procs (make-hashtable))
 
 (define (record-type-equal-procedure rtd equal-proc)
   (unless (record-type-descriptor? rtd)
     (error 'record-type-equal-procedure "expected a record type descriptor" rtd))
   (hashtable-set! $record-eq-procs rtd equal-proc))
 
+(define (record-type-hash-procedure rtd hash-proc)
+  (unless (record-type-descriptor? rtd)
+    (error 'record-type-hash-procedure "expected a record type descriptor" rtd))
+  (hashtable-set! $record-hash-procs rtd hash-proc))
+
 (define (record-equal? a b rec-equal?)
   (define a-rtd ($record-rtd a))
   (define b-rtd ($record-rtd b))
-  (cond
-    [(eq? a-rtd b-rtd)
-     (define proc (hashtable-ref $record-eq-procs a-rtd #f))
-     (cond
-       [proc
-        (let loop ([rtd a-rtd] [i 0])
-          (let ([prtd (record-type-parent rtd)])
-            (if prtd
-                (let loop2 ([fields (record-type-fields rtd)] [j 0])
-                  (if (null? fields)
-                      (loop prtd (+ i j))
-                      (let ([acc (record-accessor rtd j)])
-                        (if (rec-equal? (acc a) (acc b))
-                            (loop2 (cdr fields) (+ i 1))
-                            #f))))
-                #t)))]
-       [else
-        #f])]
-    [else
-     #f]))
+  (and (eq? a-rtd b-rtd)
+       (let ([proc (hashtable-ref $record-eq-procs a-rtd #f)])
+         (and proc (proc a b rec-equal?)))))
 
-(current-record-equal-procedure record-equal?)
+(define (record-hash r rec-hash)
+  (define rtd ($record-rtd r))
+  (define proc (hashtable-ref $record-hash-procs rtd #f))
+  (and proc (proc r rec-hash)))
+
+($current-record-equal-procedure record-equal?)
+($current-record-hash-procedure record-hash)
 
 ;;
 ;;  High-level macros
@@ -165,12 +161,13 @@
        (define protocol-rtd #f)
        (define fields-rtd '())
        (define equal-rtd #f)
+       (define hash-rtd #f)
 
        (define rname (syntax->datum #'name))
        (let loop ([clauses (syntax->list #'(cls ...))])
          (unless (null? clauses)
            (define clause (car clauses))
-           (syntax-case clause (fields parent uid sealed opaque protocol equal)
+           (syntax-case clause (fields parent uid sealed opaque protocol equal+hash)
              [(parent prtd)
               (begin
                 (when (member 'parent clause-types)
@@ -205,12 +202,13 @@
                   (syntax-error 'define-record-type "duplicate clause" stx clause))
                 (set! clause-types (cons 'protocol clause-types))
                 (set! protocol-rtd #'proc))]
-             [(equal proc)
+             [(equal+hash equal hash)
               (begin
-                (when (member 'equal clause-types)
+                (when (member 'equal+hash clause-types)
                   (syntax-error 'define-record-type "duplicate clause" stx clause))
-                (set! clause-types (cons 'equal clause-types))
-                (set! equal-rtd #'proc))]
+                (set! clause-types (cons 'equal+hash clause-types))
+                (set! equal-rtd #'equal)
+                (set! hash-rtd #'hash))]
              [(fields spec ...)
               (begin
                 (when (member 'fields clause-types)
@@ -273,6 +271,7 @@
                      [opaque?* opaque?-rtd]
                      [protocol* protocol-rtd]
                      [equal* equal-rtd]
+                     [hash* hash-rtd]
                      [(fields ...)
                       (map
                         (lambda (s)
@@ -315,7 +314,8 @@
             (define predicate (record-predicate name))
             (begin accs ...)
             (begin muts ...)
-            (when equal* (record-type-equal-procedure name equal*)))))]
+            (when equal* (record-type-equal-procedure name equal*))
+            (when hash* (record-type-hash-procedure name hash*)))))]
     [(_ name cls ...) 
      ; simplified form
      (if (identifier? #'name)

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -41,9 +41,11 @@
         (define h (make-hashtable))
         (for-each (lambda (x) (hashtable-set! h x '())) xs)
         (p h))))
-  (equal
+  (equal+hash
     (lambda (a b rec-equal?)
-      (rec-equal? (set-store a) (set-store b)))))
+      (rec-equal? (set-store a) (set-store b)))
+    (lambda (a rec-hash)
+      (+ (rec-hash (set-store a)) 401235121))))
 
 ;;
 ;;  Basic operations

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -40,7 +40,10 @@
       (lambda xs
         (define h (make-hashtable))
         (for-each (lambda (x) (hashtable-set! h x '())) xs)
-        (p h)))))
+        (p h))))
+  (equal
+    (lambda (a b rec-equal?)
+      (rec-equal? (set-store a) (set-store b)))))
 
 ;;
 ;;  Basic operations

--- a/src/library/private/set.min
+++ b/src/library/private/set.min
@@ -2,7 +2,7 @@
 ;;; Sets
 ;;;
 
-(import "pre-base.min" "list.min" "record.min")
+(import "pre-base.min" "record.min")
 (export make-set
         set?
         set-member?

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -289,6 +289,20 @@
 
   (void))
 
+;; Test 'define-enumeration'
+(let ()
+  (define-enumeration color
+    (red green blue black)
+    color-set)
+
+  (check-equal? (color red) 'red)
+  ; (equal? (color yellow) #f) ==> ERROR
+
+  (check-equal? (enum-set->list (color-set)) '())
+  (check-equal? (enum-set->list (color-set red green)) '(red green))
+  (check-equal? (enum-set->list (color-set red orange yellow green)) '(red green))
+
+  (void))
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -276,6 +276,19 @@
 
   (void))
 
+;; Test `enum-set-projection`
+(let ()
+  (define e1 (make-enumeration '(a b c d e)))
+  (define e2 (make-enumeration '(g f e d c)))
+  (define e3 (make-enumeration '(a c e g i k)))
+
+  (check-equal? (enum-set->list (enum-set-projection e1 e2)) '(e d c))
+  (check-equal? (enum-set->list (enum-set-projection e2 e1)) '(c d e))
+  (check-equal? (enum-set->list (enum-set-projection e1 e3)) '(a c e))
+  (check-equal? (enum-set->list (enum-set-projection e2 e3)) '(c e g))
+
+  (void))
+
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -1,0 +1,48 @@
+;;;
+;;; Tests for 'set'
+;;;
+
+(import "../../src/library/base.min")
+
+(define num-failed 0)
+
+(define (check-equal? d0 d1)
+  (unless (equal? d0 d1)
+    (display "[FAIL] expected ")
+    (write d1)
+    (display ", received ")
+    (write d0)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-true d)
+  (unless d
+    (display "[FAIL] expected #t")
+    (display ", received ")
+    (write d)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+(define (check-false d)
+  (when d
+    (display "[FAIL] expected #f")
+    (display ", received ")
+    (write d)
+    (newline)
+    (set! num-failed (+ num-failed 1))))
+
+; Test `make-enumeration` and `enum-set?`
+(let ()
+  (define e1 (make-enumeration '()))
+  (define e2 (make-enumeration '(a)))
+  (define e3 (make-enumeration '(a b c)))
+
+  (check-true (enum-set-type? e1))
+  (check-true (enum-set-type? e2))
+  (check-true (enum-set-type? e3))
+
+  (void))
+
+
+(when (> num-failed 0)
+  (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -31,7 +31,7 @@
     (newline)
     (set! num-failed (+ num-failed 1))))
 
-; Test `make-enumeration` and `enum-set?`
+; Test `make-enumeration`, `enum-set?`, and `enum-set->list`
 (let ()
   (define e1 (make-enumeration '()))
   (define e2 (make-enumeration '(a)))
@@ -40,6 +40,62 @@
   (check-true (enum-set-type? e1))
   (check-true (enum-set-type? e2))
   (check-true (enum-set-type? e3))
+
+  (check-equal? (enum-set->list e1) '())
+  (check-equal? (enum-set->list e2) '(a))
+  (check-equal? (enum-set->list e3) '(a b c))
+
+  (void))
+
+;; Test `enum-set-constructor`
+(let ()
+  (define e1 (make-enumeration '()))
+  (define c1 (enum-set-constructor e1))
+  (check-equal? (enum-set->list (c1 '())) '())
+  (check-equal? (enum-set->list (c1 '(c a))) '())
+  (check-equal? (enum-set->list (c1 '(b a c))) '())
+  (check-equal? (enum-set->list (c1 '(b c a))) '())
+  (check-equal? (enum-set->list (c1 '(e b d c a))) '())
+
+  (define e2 (make-enumeration '(a b c)))
+  (define c2 (enum-set-constructor e2))
+  (check-equal? (enum-set->list (c2 '())) '())
+  (check-equal? (enum-set->list (c2 '(c a))) '(a c))
+  (check-equal? (enum-set->list (c2 '(b c a))) '(a b c))
+  (check-equal? (enum-set->list (c2 '(e b d c a))) '(a b c))
+
+  (define e3 (make-enumeration '(a b c d e)))
+  (define c3 (enum-set-constructor e3))
+  (check-equal? (enum-set->list (c3 '())) '())
+  (check-equal? (enum-set->list (c3 '(c a))) '(a c))
+  (check-equal? (enum-set->list (c3 '(b c a))) '(a b c))
+  (check-equal? (enum-set->list (c3 '(e b d c a))) '(a b c d e))
+
+  (void))
+
+;; Test `enum-set-universe`
+(let ()
+  (define e1 (make-enumeration '()))
+  (define c1 (enum-set-constructor e1))
+  (check-equal? (enum-set->list (enum-set-universe (c1 '()))) '())
+  (check-equal? (enum-set->list (enum-set-universe (c1 '(c a)))) '())
+  (check-equal? (enum-set->list (enum-set-universe (c1 '(b a c)))) '())
+  (check-equal? (enum-set->list (enum-set-universe (c1 '(b c a)))) '())
+  (check-equal? (enum-set->list (enum-set-universe (c1 '(e b d c a)))) '())
+
+  (define e2 (make-enumeration '(a b c)))
+  (define c2 (enum-set-constructor e2))
+  (check-equal? (enum-set->list (enum-set-universe (c2 '()))) '(a b c))
+  (check-equal? (enum-set->list (enum-set-universe (c2 '(c a)))) '(a b c))
+  (check-equal? (enum-set->list (enum-set-universe (c2 '(b c a)))) '(a b c))
+  (check-equal? (enum-set->list (enum-set-universe (c2 '(e b d c a)))) '(a b c))
+
+  (define e3 (make-enumeration '(a b c d e)))
+  (define c3 (enum-set-constructor e3))
+  (check-equal? (enum-set->list (enum-set-universe (c3 '()))) '(a b c d e))
+  (check-equal? (enum-set->list (enum-set-universe (c3 '(c a)))) '(a b c d e))
+  (check-equal? (enum-set->list (enum-set-universe (c3 '(b c a)))) '(a b c d e))
+  (check-equal? (enum-set->list (enum-set-universe (c3 '(e b d c a)))) '(a b c d e))
 
   (void))
 

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -99,6 +99,18 @@
 
   (void))
 
+;; Test `enum-set-indexer`
+(let ()
+  (define e (make-enumeration '(a b c)))
+  (define i (enum-set-indexer e))
+
+  (check-equal? (i 'a) 0)
+  (check-equal? (i 'b) 1)
+  (check-equal? (i 'c) 2)
+  (check-equal? (i 'd) #f)
+
+  (void))
+
 ;; Test `enum-set-member?`
 (let ()
   (define e (make-enumeration '(a b c)))
@@ -138,6 +150,36 @@
   (check-false (enum-set-subset? (c1 '(b)) e2))
   (check-true (enum-set-subset? (c1 '(a)) e3))
   (check-true (enum-set-subset? (c1 '(b)) e3))
+
+  (void))
+
+; Test `enum-set=?`
+(let ()
+  (define e1 (make-enumeration '(a b)))
+  (define e2 (make-enumeration '(b c)))
+  (define e3 (make-enumeration '(a b c)))
+
+  (define c1 (enum-set-constructor e1))
+  (define c2 (enum-set-constructor e2))
+  (define c3 (enum-set-constructor e3))
+
+  (check-true (enum-set=? e1 e1))
+  (check-true (enum-set=? e2 e2))
+  (check-true (enum-set=? e3 e3))
+
+  (check-false (enum-set=? e1 e3))
+  (check-false (enum-set=? e2 e3))
+  (check-false (enum-set=? e3 e1))
+  (check-false (enum-set=? e3 e2))
+  (check-false (enum-set=? e1 e2))
+  (check-false (enum-set=? e2 e1))
+
+  (check-false (enum-set=? (c1 '(a)) e1))
+  (check-false (enum-set=? (c1 '(b)) e1))
+  (check-false (enum-set=? (c1 '(a)) e2))
+  (check-false (enum-set=? (c1 '(b)) e2))
+  (check-false (enum-set=? (c1 '(a)) e3))
+  (check-false (enum-set=? (c1 '(b)) e3))
 
   (void))
 

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -99,6 +99,48 @@
 
   (void))
 
+;; Test `enum-set-member?`
+(let ()
+  (define e (make-enumeration '(a b c)))
+
+  (check-true (enum-set-member? 'a e))
+  (check-true (enum-set-member? 'b e))
+  (check-true (enum-set-member? 'c e))
+  (check-false (enum-set-member? 'd e))
+  (check-false (enum-set-member? 'e e))
+
+  (void))
+
+;; Test `enum-set-subset?`
+(let ()
+  (define e1 (make-enumeration '(a b)))
+  (define e2 (make-enumeration '(b c)))
+  (define e3 (make-enumeration '(a b c)))
+
+  (define c1 (enum-set-constructor e1))
+  (define c2 (enum-set-constructor e2))
+  (define c3 (enum-set-constructor e3))
+
+  (check-true (enum-set-subset? e1 e1))
+  (check-true (enum-set-subset? e2 e2))
+  (check-true (enum-set-subset? e3 e3))
+
+  (check-true (enum-set-subset? e1 e3))
+  (check-true (enum-set-subset? e2 e3))
+  (check-false (enum-set-subset? e3 e1))
+  (check-false (enum-set-subset? e3 e2))
+  (check-false (enum-set-subset? e1 e2))
+  (check-false (enum-set-subset? e2 e1))
+
+  (check-true (enum-set-subset? (c1 '(a)) e1))
+  (check-true (enum-set-subset? (c1 '(b)) e1))
+  (check-false (enum-set-subset? (c1 '(a)) e2))
+  (check-false (enum-set-subset? (c1 '(b)) e2))
+  (check-true (enum-set-subset? (c1 '(a)) e3))
+  (check-true (enum-set-subset? (c1 '(b)) e3))
+
+  (void))
+
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -183,6 +183,78 @@
 
   (void))
 
+;; Test `enum-set-union`
+(let ()
+  (define e (make-enumeration '(a b c d e)))
+  (define c (enum-set-constructor e))
+
+  (define s1 (c '(a)))
+  (define s2 (c '(b)))
+  (define s3 (c '(a b)))
+  (define s4 (c '(c d e)))
+
+  (check-true (enum-set=? (enum-set-union s1 s1) s1))
+  (check-true (enum-set=? (enum-set-union s2 s2) s2))
+  (check-true (enum-set=? (enum-set-union s3 s3) s3))
+  (check-true (enum-set=? (enum-set-union s4 s4) s4))
+
+  (check-equal? (enum-set->list (enum-set-union s1 s2)) '(a b))
+  (check-equal? (enum-set->list (enum-set-union s1 s3)) '(a b))
+  (check-equal? (enum-set->list (enum-set-union s1 s4)) '(a c d e))
+  (check-equal? (enum-set->list (enum-set-union s2 s3)) '(a b))
+  (check-equal? (enum-set->list (enum-set-union s2 s4)) '(b c d e))
+  (check-equal? (enum-set->list (enum-set-union s3 s4)) '(a b c d e))
+
+  (void))
+
+;; Test `enum-set-intersect`
+(let ()
+  (define e (make-enumeration '(a b c d e)))
+  (define c (enum-set-constructor e))
+
+  (define s1 (c '(a)))
+  (define s2 (c '(b)))
+  (define s3 (c '(a b)))
+  (define s4 (c '(a b c d e)))
+
+  (check-true (enum-set=? (enum-set-intersect s1 s1) s1))
+  (check-true (enum-set=? (enum-set-intersect s2 s2) s2))
+  (check-true (enum-set=? (enum-set-intersect s3 s3) s3))
+  (check-true (enum-set=? (enum-set-intersect s4 s4) s4))
+
+  (check-equal? (enum-set->list (enum-set-intersect s1 s2)) '())
+  (check-equal? (enum-set->list (enum-set-intersect s1 s3)) '(a))
+  (check-equal? (enum-set->list (enum-set-intersect s1 s4)) '(a))
+  (check-equal? (enum-set->list (enum-set-intersect s2 s3)) '(b))
+  (check-equal? (enum-set->list (enum-set-intersect s2 s4)) '(b))
+  (check-equal? (enum-set->list (enum-set-intersect s3 s4)) '(a b))
+
+  (void))
+
+;; Test `enum-set-difference`
+(let ()
+  (define e (make-enumeration '(a b c d e)))
+  (define c (enum-set-constructor e))
+
+  (define s1 (c '(a)))
+  (define s2 (c '(b)))
+  (define s3 (c '(a b)))
+  (define s4 (c '(a b c d e)))
+
+  (check-equal? (enum-set->list (enum-set-difference s1 s1)) '())
+  (check-equal? (enum-set->list (enum-set-difference s2 s2)) '())
+  (check-equal? (enum-set->list (enum-set-difference s3 s3)) '())
+  (check-equal? (enum-set->list (enum-set-difference s4 s4)) '())
+
+  (check-equal? (enum-set->list (enum-set-difference s4 s1)) '(b c d e))
+  (check-equal? (enum-set->list (enum-set-difference s4 s2)) '(a c d e))
+  (check-equal? (enum-set->list (enum-set-difference s4 s3)) '(c d e))
+  (check-equal? (enum-set->list (enum-set-difference s3 s1)) '(b))
+  (check-equal? (enum-set->list (enum-set-difference s3 s2)) '(a))
+  (check-equal? (enum-set->list (enum-set-difference s2 s1)) '(b))
+
+  (void))
+
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -255,6 +255,27 @@
 
   (void))
 
+;; Test `enum-set-difference`
+(let ()
+  (define e (make-enumeration '(a b c d e)))
+  (define c (enum-set-constructor e))
+
+  (define s0 (c '()))
+  (define s1 (c '(a)))
+  (define s2 (c '(a b)))
+  (define s3 (c '(a b c)))
+  (define s4 (c '(a b c d)))
+  (define s5 (c '(a b c d e)))
+
+  (check-equal? (enum-set->list (enum-set-complement s0)) '(a b c d e))
+  (check-equal? (enum-set->list (enum-set-complement s1)) '(b c d e))
+  (check-equal? (enum-set->list (enum-set-complement s2)) '(c d e))
+  (check-equal? (enum-set->list (enum-set-complement s3)) '(d e))
+  (check-equal? (enum-set->list (enum-set-complement s4)) '(e))
+  (check-equal? (enum-set->list (enum-set-complement s5)) '())
+
+  (void))
+
 
 (when (> num-failed 0)
   (error #f "test failed"))

--- a/test/base/enum.min
+++ b/test/base/enum.min
@@ -37,9 +37,9 @@
   (define e2 (make-enumeration '(a)))
   (define e3 (make-enumeration '(a b c)))
 
-  (check-true (enum-set-type? e1))
-  (check-true (enum-set-type? e2))
-  (check-true (enum-set-type? e3))
+  (check-true (enum-set? e1))
+  (check-true (enum-set? e2))
+  (check-true (enum-set? e3))
 
   (check-equal? (enum-set->list e1) '())
   (check-equal? (enum-set->list e2) '(a))

--- a/test/base/record.min
+++ b/test/base/record.min
@@ -242,9 +242,11 @@
 (let ()
   (define-record-type foo
     (fields a)
-    (equal
+    (equal+hash
       (lambda (a b rec-equal?)
-        (rec-equal? (foo-a a) (foo-a b)))))
+        (rec-equal? (foo-a a) (foo-a b)))
+      (lambda (a rec-hash)
+        (+ (rec-hash (foo-a a)) 401235121))))
 
   (define f1 (make-foo 1))
   (define f2 (make-foo 1))
@@ -253,15 +255,17 @@
   (check-equal? f1 f2)
   (check-not-equal? f1 f3)
 
-  ; (check-equal? (equal-hash f1) (equal-hash f2))
-  ; (check-not-equal? (equal-hash f1) (equal-hash f3))
+  (check-equal? (equal-hash f1) (equal-hash f2))
+  (check-not-equal? (equal-hash f1) (equal-hash f3))
 
   (define-record-type bar
     (fields a b)
-    (equal
+    (equal+hash
       (lambda (a b rec-equal?)
         (and (rec-equal? (bar-a a) (bar-a b))
-             (rec-equal? (bar-b a) (bar-b b))))))
+             (rec-equal? (bar-b a) (bar-b b))))
+      (lambda (a rec-hash)
+        (+ (rec-hash (bar-a a)) (rec-hash (bar-b a)) 401235121))))
 
   (define b1 (make-bar 1 2))
   (define b2 (make-bar 1 2))
@@ -270,16 +274,15 @@
   (check-equal? b1 b2)
   (check-not-equal? b1 b3)
 
-  ; (check-equal? (equal-hash b1) (equal-hash b2))
-  ; (check-not-equal? (equal-hash b1) (equal-hash b3))
-  ; (check-not-equal? (equal-hash foo) (equal-hash bar))
+  (check-equal? (equal-hash b1) (equal-hash b2))
+  (check-not-equal? (equal-hash b1) (equal-hash b3))
+  (check-not-equal? (equal-hash foo) (equal-hash bar))
 
   (define-record-type baz
     (fields a))
 
-  (check-not-equal? (baz 1) (baz 1))
-  (check-not-equal? (baz 1) (baz 2))
-
+  (check-not-equal? (make-baz 1) (make-baz 1))
+  (check-not-equal? (make-baz 1) (make-baz 2))
   (check-not-equal? foo bar)
 
   (void))

--- a/test/base/record.min
+++ b/test/base/record.min
@@ -241,7 +241,10 @@
 ;; Test record equality
 (let ()
   (define-record-type foo
-    (fields a))
+    (fields a)
+    (equal
+      (lambda (a b rec-equal?)
+        (rec-equal? (foo-a a) (foo-a b)))))
 
   (define f1 (make-foo 1))
   (define f2 (make-foo 1))
@@ -250,11 +253,15 @@
   (check-equal? f1 f2)
   (check-not-equal? f1 f3)
 
-  (check-equal? (equal-hash f1) (equal-hash f2))
-  (check-not-equal? (equal-hash f1) (equal-hash f3))
+  ; (check-equal? (equal-hash f1) (equal-hash f2))
+  ; (check-not-equal? (equal-hash f1) (equal-hash f3))
 
   (define-record-type bar
-    (fields a b))
+    (fields a b)
+    (equal
+      (lambda (a b rec-equal?)
+        (and (rec-equal? (bar-a a) (bar-a b))
+             (rec-equal? (bar-b a) (bar-b b))))))
 
   (define b1 (make-bar 1 2))
   (define b2 (make-bar 1 2))
@@ -263,11 +270,17 @@
   (check-equal? b1 b2)
   (check-not-equal? b1 b3)
 
-  (check-equal? (equal-hash b1) (equal-hash b2))
-  (check-not-equal? (equal-hash b1) (equal-hash b3))
+  ; (check-equal? (equal-hash b1) (equal-hash b2))
+  ; (check-not-equal? (equal-hash b1) (equal-hash b3))
+  ; (check-not-equal? (equal-hash foo) (equal-hash bar))
+
+  (define-record-type baz
+    (fields a))
+
+  (check-not-equal? (baz 1) (baz 1))
+  (check-not-equal? (baz 1) (baz 2))
 
   (check-not-equal? foo bar)
-  (check-not-equal? (equal-hash foo) (equal-hash bar))
 
   (void))
 


### PR DESCRIPTION
This PR adds enumeration sets, as described in R6RS. The following procedures define the `enum-set` interface:
```
define-enumeration
make-enumeration
enum-set?
enum-set->list
enum-set-universe
enum-set-constructor
enum-set-indexer
enum-set-member?
enum-set-subset?
enum-set=?
enum-set-union
enum-set-intersect
enum-set-difference
enum-set-complement
enum-set-projection
```
In addition, record equality was reverted to always `#f` by default. Two procedures have been added to modify record behavior under `equal?` and `equal-hash`:
```
record-type-equal-procedure
record-type-hash-procedure
```
Alternatively, these procedures can be specified in the `define-record-type` macro using the clause:
```
(equal+hash equal-proc hash-proc)
```